### PR TITLE
New Cast Logic and beginning support for Revelations

### DIFF
--- a/backend/src/main/java/com/google/rolecall/jsonobjects/PositionInfo.java
+++ b/backend/src/main/java/com/google/rolecall/jsonobjects/PositionInfo.java
@@ -26,6 +26,10 @@ public abstract class PositionInfo {
   public abstract Integer order();
 
   @Nullable
+  @JsonProperty("siblingId")
+  public abstract Integer siblingId();
+
+  @Nullable
   @JsonProperty("size")
   public abstract Integer size();
 
@@ -61,6 +65,9 @@ public abstract class PositionInfo {
 
     @JsonProperty("order")
     public abstract Builder setOrder(Integer order);
+
+    @JsonProperty("siblingId")
+    public abstract Builder setSiblingId(Integer siblingId);
 
     @JsonProperty("size")
     public abstract Builder setSize(Integer size);

--- a/backend/src/main/java/com/google/rolecall/jsonobjects/SectionInfo.java
+++ b/backend/src/main/java/com/google/rolecall/jsonobjects/SectionInfo.java
@@ -28,6 +28,10 @@ public abstract class SectionInfo {
   public abstract Integer length();
 
   @Nullable
+  @JsonProperty("siblingId")
+  public abstract Integer siblingId();
+
+  @Nullable
   @JsonProperty("type")
   public abstract Type type();
 
@@ -64,6 +68,9 @@ public abstract class SectionInfo {
 
     @JsonProperty("length")
     public abstract Builder setLength(Integer length);
+
+    @JsonProperty("siblingId")
+    public abstract Builder setSiblingId(Integer siblingId);
 
     @JsonProperty("type")
     public abstract Builder setType(Type type);

--- a/backend/src/main/java/com/google/rolecall/models/Position.java
+++ b/backend/src/main/java/com/google/rolecall/models/Position.java
@@ -142,7 +142,7 @@ public class Position {
     private Integer size;
     private Section section;
 
-    public Builder setId(Integer id) {
+    public Builder setIdUnsafe(Integer id) {
       if(id != null) {
         this.id = id;
       }

--- a/backend/src/main/java/com/google/rolecall/models/Position.java
+++ b/backend/src/main/java/com/google/rolecall/models/Position.java
@@ -142,7 +142,8 @@ public class Position {
     private Integer size;
     private Section section;
 
-    public Builder setIdUnsafe(Integer id) {
+    // Violates pattern for auto generated index. Use with caution.
+    public Builder setId(Integer id) {
       if(id != null) {
         this.id = id;
       }

--- a/backend/src/main/java/com/google/rolecall/models/Position.java
+++ b/backend/src/main/java/com/google/rolecall/models/Position.java
@@ -35,6 +35,9 @@ public class Position {
   private Integer order;
 
   @Basic
+  private Integer siblingId;
+
+  @Basic
   private Integer size;
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
@@ -59,6 +62,10 @@ public class Position {
 
   public int getOrder() {
     return order;
+  }
+
+  public Integer getSiblingId() {
+    return siblingId;
   }
 
   public Integer getSize() {
@@ -91,6 +98,7 @@ public class Position {
         .setName(getName())
         .setNotes(getNotes())
         .setOrder(getOrder())
+        .setSiblingId(getSiblingId())
         .setSize(getSize())
         .build();
   }
@@ -130,8 +138,16 @@ public class Position {
     private String name;
     private String notes;
     private Integer order;
+    private Integer siblingId;
     private Integer size;
     private Section section;
+
+    public Builder setId(Integer id) {
+      if(id != null) {
+        this.id = id;
+      }
+      return this;
+    }
 
     public Builder setName(String name) {
       if(name != null) {
@@ -154,6 +170,13 @@ public class Position {
       return this;
     }
 
+    public Builder setSiblingId(Integer siblingId) {
+      if(siblingId != null) {
+        this.siblingId = siblingId == 0 ? null : siblingId;
+      }
+      return this;
+    }
+
     public Builder setSize(Integer size) {
       if(size != null) {
         this.size = size;
@@ -169,6 +192,7 @@ public class Position {
       position.name = this.name;
       position.notes = this.notes;
       position.order = this.order;
+      position.siblingId = this.siblingId;
       position.size = this.size;
       position.section = this.section;
 
@@ -181,6 +205,7 @@ public class Position {
       this.name = position.name;
       this.notes = position.notes;
       this.order = position.order;
+      this.siblingId = position.siblingId;
       this.size = position.size;
       this.section = position.section;
     }

--- a/backend/src/main/java/com/google/rolecall/models/Section.java
+++ b/backend/src/main/java/com/google/rolecall/models/Section.java
@@ -28,7 +28,8 @@ public class Section {
 
   public enum Type {
     PIECE,
-    SEGMENT
+    SEGMENT,
+    REVELATION,
   }
 
   @Id
@@ -43,6 +44,9 @@ public class Section {
 
   @Basic
   private Integer length;
+
+  @Basic
+  private Integer siblingId;
 
   @Enumerated(EnumType.ORDINAL)
   private Type type;
@@ -75,6 +79,10 @@ public class Section {
     return length == null ? Optional.empty() : Optional.of(length);
   }
 
+  public Integer getSiblingId() {
+    return siblingId;
+  }
+
   public Type getType() {
     return type;
   }
@@ -96,6 +104,7 @@ public class Section {
         .setName(name)
         .setNotes(getNotes())
         .setLength(length)
+        .setSiblingId(siblingId)
         .setType(type)
         .setPositions(positionInfos)
         .build();
@@ -181,7 +190,16 @@ public class Section {
     private String name;
     private String notes;
     private Integer length;
+    private Integer siblingId;
     private Type type;
+
+    public Builder setId(Integer id) {
+      if(id != null) {
+        this.id = id;
+      }
+
+      return this;
+    }
 
     public Builder setName(String name) {
       if(name != null) {
@@ -207,6 +225,13 @@ public class Section {
       return this;
     }
 
+    public Builder setSiblingId(Integer siblingId) {
+      if(siblingId != null) {
+        this.siblingId = siblingId == 0 ? null : siblingId;
+      }
+      return this;
+    }
+
     public Builder setType(Type type) {
       if(type != null) {
         this.type = type;
@@ -224,6 +249,7 @@ public class Section {
       section.name = this.name;
       section.notes = this.notes;
       section.length = this.length;
+      section.siblingId = this.siblingId;
       section.type = this.type;
 
       return section;
@@ -235,6 +261,7 @@ public class Section {
       this.name = section.name;
       this.notes = section.notes;
       this.length = section.length;
+      this.siblingId = section.siblingId;
       this.type = section.type;
     }
 

--- a/backend/src/main/java/com/google/rolecall/models/Section.java
+++ b/backend/src/main/java/com/google/rolecall/models/Section.java
@@ -193,7 +193,8 @@ public class Section {
     private Integer siblingId;
     private Type type;
 
-    public Builder setIdUnsafe(Integer id) {
+    // Violates pattern for auto generated index. Use with caution.
+    public Builder setId(Integer id) {
       if(id != null) {
         this.id = id;
       }

--- a/backend/src/main/java/com/google/rolecall/models/Section.java
+++ b/backend/src/main/java/com/google/rolecall/models/Section.java
@@ -193,11 +193,10 @@ public class Section {
     private Integer siblingId;
     private Type type;
 
-    public Builder setId(Integer id) {
+    public Builder setIdUnsafe(Integer id) {
       if(id != null) {
         this.id = id;
       }
-
       return this;
     }
 
@@ -205,7 +204,6 @@ public class Section {
       if(name != null) {
         this.name = name;
       }
-
       return this;
     }
 
@@ -213,7 +211,6 @@ public class Section {
       if(notes != null) {
         this.notes = notes;
       }
-
       return this;
     }
 
@@ -221,7 +218,6 @@ public class Section {
       if(length != null) {
         this.length = length;
       }
-
       return this;
     }
 
@@ -236,7 +232,6 @@ public class Section {
       if(type != null) {
         this.type = type;
       }
-
       return this;
     }
 

--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -132,8 +132,9 @@ public class SectionServices {
       // Update sibling Ballets with ids of Revelation's internal Ballet/Position structures
       int i = 0;
       for(Position pos: savedSection.getPositions()) {
+
         Section subSection = Section.newBuilder()
-            .setId(ixArray[i])
+            .setIdUnsafe(ixArray[i])
             .setName(pos.getName())
             .setNotes("")
             .setLength(0)
@@ -293,7 +294,7 @@ public class SectionServices {
       for(Position pos: savedSection.getPositions()) {
         if(ixArray[i] > -1) {
           Section subSection = Section.newBuilder()
-              .setId(ixArray[i])
+              .setIdUnsafe(ixArray[i])
               .setName(pos.getName())
               .setNotes("")
               .setLength(0)
@@ -352,7 +353,7 @@ public class SectionServices {
         try {
           Position sibling = queryPosition.get();
           Position updatedSibling = sibling.toBuilder()
-              .setId(positionId)
+              .setIdUnsafe(positionId)
               .setName(newName == null || newName.length() == 0 ? sibling.getName() : newName)
               .setNotes(sibling.getNotes())
               .setOrder(sibling.getOrder())
@@ -381,7 +382,7 @@ public class SectionServices {
         try {
           Section sibling = querySection.get();
           Section updatedSibling = sibling.toBuilder()
-              .setId(sectionId)
+              .setIdUnsafe(sectionId)
               .setName(newName == null || newName.length() == 0 ? sibling.getName() : newName)
               .setNotes(sibling.getNotes())
               .setLength(sibling.getLength().get())

--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -92,8 +92,8 @@ public class SectionServices {
     Integer[] siblingIndexArray = new Integer[newSection.positions().size()];
     if(newSection.positions() != null && !newSection.positions().isEmpty()) {
       Set<Integer> orders = new HashSet<>();
-      int loopCounter = 0;
-      for(PositionInfo info: newSection.positions()) {
+      for(int loopCounter = 0; loopCounter < newSection.positions().size(); loopCounter++) {
+        PositionInfo info = newSection.positions().get(loopCounter);
         Section savedSubSection = null;
 
         if(isParentRevelation) {
@@ -123,11 +123,10 @@ public class SectionServices {
         }
         orders.add(position.getOrder());
         section.addPosition(position);
-        loopCounter += 1;
       }
     }
     Section savedSection = sectionRepo.save(section);
-    UpdateRevelationChildren(savedSection, siblingIndexArray, isParentRevelation);
+    updateRevelationChildren(savedSection, siblingIndexArray, isParentRevelation);
     return savedSection;
   }
 
@@ -169,8 +168,8 @@ public class SectionServices {
     if(isParentRevelation) {
       // Check for sibling of Ballet children of Revelation section
       if(newSection.positions() != null && !newSection.positions().isEmpty()) {
-        int i = 0;
-        for(PositionInfo info: newSection.positions()) {
+        for(int loopCounter = 0; loopCounter < newSection.positions().size(); loopCounter++) {
+          PositionInfo info = newSection.positions().get(loopCounter);
           if(info.delete() != null && info.delete()) {
             // Deleting position items
             Integer siblingId = info.siblingId();
@@ -188,11 +187,10 @@ public class SectionServices {
             if(positionSiblingId != null) { 
               SiblingError errCd = updateSiblingSection(positionSiblingId, info.name(), -1);
               if (errCd != SiblingError.OK) {
-                badIdArray[i] = 1;
+                badIdArray[loopCounter] = 1;
               }
             }
           }
-          i += 1;
         }
       }
     }
@@ -209,8 +207,8 @@ public class SectionServices {
 
     if(newSection.positions() != null && !newSection.positions().isEmpty()) {
       List<Position> positions = section.getPositions();
-      int loopCounter = 0;
-      for(PositionInfo info: newSection.positions()) {
+      for(int loopCounter = 0; loopCounter < newSection.positions().size(); loopCounter++) {
+        PositionInfo info = newSection.positions().get(loopCounter);
         Position position;
         Section savedSubSection = null;
         if(info.delete() != null && info.delete()) {
@@ -258,7 +256,6 @@ public class SectionServices {
             .setSize(isParentRevelation ? -1 : info.size())
             .build();
         section.addPosition(position);
-        loopCounter += 1;
       }
 
       Set<Integer> orders = new HashSet<>();
@@ -270,7 +267,7 @@ public class SectionServices {
       }
     }
     Section savedSection = sectionRepo.save(section);
-    UpdateRevelationChildren(savedSection, siblingIndexArray, isParentRevelation);
+    updateRevelationChildren(savedSection, siblingIndexArray, isParentRevelation);
     return savedSection;
   }
 
@@ -307,12 +304,12 @@ public class SectionServices {
 
   // Utility functions
 
-  private void UpdateRevelationChildren(Section section, Integer[] siblingIndexArray,
+  private void updateRevelationChildren(Section section, Integer[] siblingIndexArray,
       boolean isParentRevelation) throws InvalidParameterException {
     if(isParentRevelation) {
       // Update sibling Ballets with ids of Revelation's internal Ballet/Position structures
-      int loopCounter = 0;
-      for(Position pos: section.getPositions()) {
+      for(int loopCounter = 0; loopCounter < section.getPositions().size(); loopCounter++) {
+        Position pos = section.getPositions().get(loopCounter);
   
         Section subSection = Section.newBuilder()
             .setId(siblingIndexArray[loopCounter])
@@ -323,7 +320,6 @@ public class SectionServices {
             .setType(Section.Type.PIECE)
             .build();
         sectionRepo.save(subSection);
-        loopCounter += 1;
       }
     }
   }

--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -85,7 +85,7 @@ public class SectionServices {
         .setName(newSection.name())
         .setNotes(newSection.notes())
         .setLength(newSection.length())
-        .setSiblingId(newSection.length())
+        .setSiblingId(newSection.siblingId())
         .setType(newSection.type())
         .build();
 
@@ -103,7 +103,7 @@ public class SectionServices {
               .setName(info.name())
               .setNotes("")
               .setLength(0)
-              .setSiblingId(null)
+              .setSiblingId(0)
               .setType(Section.Type.PIECE)
               .build();
           savedSubSection = sectionRepo.save(subSection);
@@ -168,8 +168,6 @@ public class SectionServices {
       InvalidParameterException {
     Boolean isParentRevelation = newSection.type() == Section.Type.REVELATION;
 
-    System.out.printf("UPDATING %s\n", newSection.name());
-
     // Make sure that sibling Ballet and Position / Ballet items are synchronized
 
     // Check for sibling of Ballet section
@@ -190,17 +188,13 @@ public class SectionServices {
       if(newSection.positions() != null && !newSection.positions().isEmpty()) {
         int i = 0;
         for(PositionInfo info: newSection.positions()) {
-          System.out.printf("LOOPING i=%d\n", i);
-          System.out.printf("SECTION=%s\n", newSection.name());
           if(info.delete() != null && info.delete()) {
-            System.out.printf("Deleting %s\n", info.name());
             // Deleting position items
             Integer siblingId = info.siblingId();
             if(siblingId != null) {
               Integer positionSiblingId = info.siblingId();
               if(positionSiblingId != null) {
                 // Erase reference in sibling
-                System.out.printf("Deleting %d\n", positionSiblingId);
                 updateSiblingSection(positionSiblingId, "", 0);
               }  
             }
@@ -234,7 +228,6 @@ public class SectionServices {
       List<Position> positions = section.getPositions();
       int i = 0;
       for(PositionInfo info: newSection.positions()) {
-        System.out.printf("LAST LOOP %d\n", i);
         Position position;
         Section savedSubSection = null;
         if(info.delete() != null && info.delete()) {
@@ -258,7 +251,6 @@ public class SectionServices {
         } else {
           ixArray[i] = -1;
           if(isParentRevelation) {
-            System.out.printf("BEFORE WRITING\n");
             // New Ballet-Child
             // Create sibling Ballets to Revelation's internal Ballet/Position structures
             // The ids will be inserted into Revelation's internal Ballet/Position structures
@@ -266,7 +258,7 @@ public class SectionServices {
                 .setName(info.name())
                 .setNotes("")
                 .setLength(0)
-                .setSiblingId(null)
+                .setSiblingId(0)
                 .setType(Section.Type.PIECE)
                 .build();
             savedSubSection = sectionRepo.save(subSection);
@@ -368,10 +360,6 @@ public class SectionServices {
               .setSize(sibling.getSiblingId())
               .build();
           positionRepo.save(updatedSibling);
-          System.out.printf("Saved Sibling Position %s at id %d SiblingId=%d\n",
-              newName == null || newName.length() == 0 ? sibling.getName() : newName,
-              positionId,
-              siblingId == -1 ? sibling.getSiblingId() : siblingId);
         } catch (InvalidParameterException e) {
           return SiblingError.OTHER_ERROR;
         }
@@ -387,8 +375,6 @@ public class SectionServices {
     if(sectionId != null) {
       Optional<Section> querySection = sectionRepo.findById(sectionId);
 
-      //System.out.printf("Section Update id=%d name=%s siblingIs=%d\n", sectionId, newName, siblingId);
-
       if(querySection.isEmpty()) {
         return SiblingError.SIBLING_MISSING;
       } else {
@@ -403,10 +389,6 @@ public class SectionServices {
               .setType(sibling.getType())
               .build();
           sectionRepo.save(updatedSibling);
-          System.out.printf("Saved Sibling Ballet %s at id %d SiblingId=%d\n",
-              newName == null || newName.length() == 0 ? sibling.getName() : newName,
-              sectionId,
-              siblingId == -1 ? sibling.getSiblingId() : siblingId);
         } catch (InvalidParameterException e) {
           return SiblingError.OTHER_ERROR;
         }

--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -35,18 +35,27 @@ type AllRawCastsResponse = {
   warnings: string[]
 }
 
+export type CastMember = {
+  uuid: string;
+  position_number: number;
+}
+
+export type CastSubCast = {
+  position_uuid?: string;
+  group_index: number;
+  members: CastMember[];
+}
+
+export type CastPosition = {
+  position_uuid: string;
+  groups: CastSubCast[];
+}
+
 export type Cast = {
   uuid: string;
   name: string;
   segment: string;
-  filled_positions: {
-    position_uuid: string,
-    groups: {
-      position_uuid?: string,
-      group_index: number,
-      members: { uuid: string, position_number: number }[]
-    }[]
-  }[];
+  filled_positions: CastPosition[];
 }
 
 export type AllCastsResponse = {
@@ -104,7 +113,10 @@ export class CastApi {
         headers: header,
         observe: "response",
         withCredentials: true
-      }).toPromise().catch((errorResp) => errorResp).then((resp) => this.respHandler.checkResponse<AllRawCastsResponse>(resp)).then((val) => {
+      })
+      .toPromise()
+      .catch((errorResp) => errorResp)
+      .then((resp) => this.respHandler.checkResponse<AllRawCastsResponse>(resp)).then((val) => {
         this.rawCasts = val.data;
         let allPositions: Position[] = [];
         Array.from(this.pieceAPI.pieces.values()).forEach(piece => {

--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -12,6 +12,7 @@ type RawPosition = {
   name: string,
   notes: string,
   order: number,
+  siblingId: number,
   size: number,
 }
 
@@ -19,7 +20,8 @@ type RawPiece = {
   id: number,
   name: string,
   notes: string,
-  type: "SEGMENT" | "PIECE",
+  siblingId: number,
+  type: "SEGMENT" | "PIECE" | "REVELATION",
   length: number,
   positions: RawPosition[],
 }
@@ -35,13 +37,17 @@ export type Position = {
   name: string,
   notes: string,
   order: number,
+  siblingId: number,
   size: number,
 };
+
+export type PieceType = "SEGMENT" | "PIECE" | "REVELATION";
 
 export type Piece = {
   uuid: string;
   name: string;
-  type: "SEGMENT" | "PIECE";
+  siblingId: number,
+  type: PieceType;
   positions: Position[];
   deletePositions: Position[];
 }
@@ -105,6 +111,7 @@ export class PieceApi {
             return {
               uuid: String(section.id),
               name: section.name,
+              siblingId: section.siblingId,
               type: section.type,
               positions: section.positions.sort((a, b) => a.order < b.order ? -1 : 1)
                   .map(pos => { return { ...pos, uuid: String(pos.id) } }),
@@ -135,6 +142,7 @@ export class PieceApi {
       return this.http.patch(environment.backendURL + 'api/section', {
         name: piece.name,
         id: Number(piece.uuid),
+        siblingId: piece.siblingId,
         type: piece.type ? piece.type : "PIECE",
         positions: piece.positions.map((val, ind) => {
           return {
@@ -160,6 +168,7 @@ export class PieceApi {
       let header = await this.headerUtil.generateHeader();
       return this.http.post(environment.backendURL + 'api/section', {
         name: piece.name,
+        siblingId: piece.siblingId,
         type: piece.type ? piece.type : "PIECE",
         positions: piece.positions
       }, {
@@ -279,6 +288,4 @@ export class PieceApi {
       }
     });
   }
-
-
 }

--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -21,7 +21,7 @@ type RawPiece = {
   name: string,
   notes: string,
   siblingId: number,
-  type: "SEGMENT" | "PIECE" | "REVELATION",
+  type: PieceType,
   length: number,
   positions: RawPosition[],
 }

--- a/frontend/rolecall/src/app/app/app.module.ts
+++ b/frontend/rolecall/src/app/app/app.module.ts
@@ -2,6 +2,7 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { ClassProvider, NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -34,8 +35,9 @@ const LOGGING_INTERCEPTOR_PROVIDER: ClassProvider = {
     HttpClientModule,
     BrowserModule,
     BrowserAnimationsModule,
-    MatIconModule,
     MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
     NgbModule,
     LoginModule,
     // Routing

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
@@ -1,51 +1,77 @@
-<div *ngIf="dataLoaded && castSelected" class="drop-group-container" cdkDropListGroup>
+<div *ngIf="dataLoaded && castSelected"
+    class="drop-group-container"
+    cdkDropListGroup>
   <div class="position-pool">
-    <div *ngIf="buttonsEnabled" class="name-export-container">
-      <input type="text" class="name-input" (input)="onTitleInput($event)" [value]="this.cast.name"
-        [size]="this.cast.name.length < 15 ? 15 : this.cast.name.length" />
-      <button mat-icon-button aria-label="Export Cast Button" class="export-button" (click)="exportCast()">
+    <div *ngIf="buttonsEnabled"
+        class="name-export-container">
+      <input type="text"
+          class="name-input"
+          (input)="onTitleInput($event)"
+          [value]="this.cast.name"
+          [size]="this.cast.name.length < 15 ? 15 : this.cast.name.length" />
+      <button mat-icon-button
+          aria-label="Export Cast Button"
+          class="export-button"
+          (click)="exportCast()">
         <mat-icon [inline]="true" class="export-button-icon">
           save_alt
         </mat-icon>
       </button>
     </div>
-    <div *ngFor="let position of castPositions; let i1 = index" class="position-container">
+    <div *ngFor="let position of castPositions; let i1 = index"
+        class="position-container">
       <div *ngIf="i1 < castPositions.length">
         <div class="table-container">
-          <div class="horizontal-list" id="col-headers">
+          <div class="horizontal-list"
+              id="col-headers">
             <div class="cell cellBothHeader">
               {{ castPositions[i1].pos.name }}
             </div>
             <div class="dancer-count-buttons-container">
-              <button mat-icon-button aria-label="Increment Dancer Count Button" class="dancer-count-button"
-                  [disabled]="position.castSize < 2" (click)="decrementDancerCount(i1)">
-                <mat-icon [inline]="true" class="dancer-count-icon">
+              <button mat-icon-button
+                  aria-label="Decrement Dancer Count Button"
+                  class="dancer-count-button"
+                  [disabled]="position.castSize < 2"
+                  (click)="decrementDancerCount(i1)">
+                <mat-icon [inline]="true"
+                    class="dancer-count-icon">
                   remove_circle_outline
                 </mat-icon>
               </button>
-              <button mat-icon-button aria-label="Increment Dancer Count Button" class="dancer-count-button"
+              <button mat-icon-button
+                  aria-label="Increment Dancer Count Button"
+                  class="dancer-count-button"
                   (click)="incrementDancerCount(i1)">
-                <mat-icon [inline]="true" class="dancer-count-icon">
+                <mat-icon [inline]="true"
+                    class="dancer-count-icon">
                   add_circle_outline
                 </mat-icon>
               </button>
             </div>
-            <div *ngFor="let header of subCastHeaders" class="cell cellColHeader">
+            <div *ngFor="let header of subCastHeaders"
+                class="cell cellColHeader">
                 {{ header }}
             </div>
           </div>
-          <div cdkDropList cdkDropListOrientation="horizontal" class="horizontal-list" [cdkDropListData]="row"
-              *ngFor="let row of position.castRows; let i2 = index" (cdkDropListDropped)="drop($event)" [id]="i1 + ':' + i2">
+          <div class="horizontal-list"
+              cdkDropList
+              cdkDropListOrientation="horizontal"
+              class="horizontal-list"
+              [cdkDropListData]="row"
+              *ngFor="let row of position.castRows; let i2 = index"
+              (cdkDropListDropped)="drop($event)"
+              [id]="i1 + ':' + i2">
             <div class="cell cellRowHeader">
               {{ "Dancer" + (position.castSize > 1 ? " #" + (i2 + 1) : "") }}
             </div>
-            <div class="cell" *ngFor="let dancer of position.castRows[i2].subCastDancers; let i3 = index" cdkDrag [cdkDragData]="dancer"
+            <div *ngFor="let dancer of position.castRows[i2].subCastDancers; let i3 = index"
+                class="cell"
+                cdkDrag
+                [cdkDragData]="dancer"
                 [ngStyle]="i3 == boldedCast ? {'font-weight' : 'bold'} : {}">
               <div *ngIf="dancer!==undefined">
-
                 <img class="user-image"
                     [src]="'https://i.pravatar.cc/150?u=' + dancer.firstName + '::::' + dancer.lastName + dancer.email">
-
                 {{dancer.firstName + " " + dancer.lastName}}
               </div>
             </div>
@@ -55,21 +81,33 @@
     </div>
   </div>
   <div class="user-container">
-    <div cdkDropList cdkDropListOrientation="horizontal" class="horizontal-list user-pool" [cdkDropListData]="allUsers"
-      (cdkDropListDropped)="drop($event)" id="user-pool">
-      <div *ngFor="let user of allUsers" class="cell user-cell" cdkDrag [cdkDragData]="user">
+    <div class="horizontal-list user-pool"
+        cdkDropList
+        cdkDropListOrientation="horizontal"
+        [cdkDropListData]="allUsers"
+        (cdkDropListDropped)="drop($event)"
+        id="user-pool">
+      <div *ngFor="let user of allUsers"
+          class="cell user-cell"
+          cdkDrag
+          [cdkDragData]="user">
         <img class="user-image"
             [src]="'https://i.pravatar.cc/150?u=' + user.first_name + '::::' + user.last_name + user.contact_info.email">
         {{user.first_name + " " + user.last_name}}
       </div>
     </div>
-    <div *ngIf="buttonsEnabled" class="buttons-container">
-      <button mat-icon-button class="save-delete-button" (click)="deleteCast()">
+    <div *ngIf="buttonsEnabled"
+        class="buttons-container">
+      <button mat-icon-button
+          class="save-delete-button"
+          (click)="deleteCast()">
         <mat-icon class="save-delete-button-icon">
           delete
         </mat-icon>
       </button>
-      <button mat-icon-button class="save-delete-button" (click)="saveCast()">
+      <button mat-icon-button
+          class="save-delete-button"
+          (click)="saveCast()">
         <mat-icon class="save-delete-button-icon">
           save
         </mat-icon>

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
@@ -9,30 +9,46 @@
         </mat-icon>
       </button>
     </div>
-    <div *ngFor="let position of data; let i1 = index" class="position-container">
-      <div *ngIf="i1 < positionVals.length">
-        <h3 class="position-title">{{positionVals[i1].name}}</h3>
+    <div *ngFor="let position of castPositions; let i1 = index" class="position-container">
+      <div *ngIf="i1 < castPositions.length">
         <div class="table-container">
           <div class="horizontal-list" id="col-headers">
             <div class="cell cellBothHeader">
+              {{ castPositions[i1].pos.name }}
             </div>
-            <div *ngFor="let header of columnHeaders[i1]" class="cell cellColHeader">
-              {{ header }}
+            <div class="dancer-count-buttons-container">
+              <button mat-icon-button aria-label="Increment Dancer Count Button" class="dancer-count-button"
+                  [disabled]="position.castSize < 2" (click)="decrementDancerCount(i1)">
+                <mat-icon [inline]="true" class="dancer-count-icon">
+                  remove_circle_outline
+                </mat-icon>
+              </button>
+              <button mat-icon-button aria-label="Increment Dancer Count Button" class="dancer-count-button"
+                  (click)="incrementDancerCount(i1)">
+                <mat-icon [inline]="true" class="dancer-count-icon">
+                  add_circle_outline
+                </mat-icon>
+              </button>
+            </div>
+            <div *ngFor="let header of subCastHeaders" class="cell cellColHeader">
+                {{ header }}
             </div>
           </div>
           <div cdkDropList cdkDropListOrientation="horizontal" class="horizontal-list" [cdkDropListData]="row"
-            *ngFor="let row of position; let i2 = index" (cdkDropListDropped)="drop($event)" [id]="i1 + ':' + i2">
+              *ngFor="let row of position.castRows; let i2 = index" (cdkDropListDropped)="drop($event)" [id]="i1 + ':' + i2">
             <div class="cell cellRowHeader">
-              {{ positionVals[i1].name + " " + (i2 + 1) }}
+              {{ "Dancer" + (position.castSize > 1 ? " #" + (i2 + 1) : "") }}
             </div>
-            <div class="cell" *ngFor="let person of row; let i3 = index" cdkDrag [cdkDragData]="person"
-              [ngStyle]="i3 == boldedCast ? {'font-weight' : 'bold'} : {}">
-              <img class="user-image"
-                [src]="'https://i.pravatar.cc/150?u=' + person.first_name + '::::' + person.last_name + person.contact_info.email">
-              {{person.first_name + " " + person.last_name}}
+            <div class="cell" *ngFor="let dancer of position.castRows[i2].subCastDancers; let i3 = index" cdkDrag [cdkDragData]="dancer"
+                [ngStyle]="i3 == boldedCast ? {'font-weight' : 'bold'} : {}">
+              <div *ngIf="dancer!==undefined">
+
+                <img class="user-image"
+                    [src]="'https://i.pravatar.cc/150?u=' + dancer.firstName + '::::' + dancer.lastName + dancer.email">
+
+                {{dancer.firstName + " " + dancer.lastName}}
+              </div>
             </div>
-            <!-- <div class="empty-cell" *ngFor="let empty of emptyCells[i1][i2]">
-        </div> -->
           </div>
         </div>
       </div>
@@ -43,7 +59,7 @@
       (cdkDropListDropped)="drop($event)" id="user-pool">
       <div *ngFor="let user of allUsers" class="cell user-cell" cdkDrag [cdkDragData]="user">
         <img class="user-image"
-          [src]="'https://i.pravatar.cc/150?u=' + user.first_name + '::::' + user.last_name + user.contact_info.email">
+            [src]="'https://i.pravatar.cc/150?u=' + user.first_name + '::::' + user.last_name + user.contact_info.email">
         {{user.first_name + " " + user.last_name}}
       </div>
     </div>

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.html
@@ -53,12 +53,11 @@
                 {{ header }}
             </div>
           </div>
-          <div class="horizontal-list"
+          <div *ngFor="let row of position.castRows; let i2 = index"
               cdkDropList
               cdkDropListOrientation="horizontal"
               class="horizontal-list"
               [cdkDropListData]="row"
-              *ngFor="let row of position.castRows; let i2 = index"
               (cdkDropListDropped)="drop($event)"
               [id]="i1 + ':' + i2">
             <div class="cell cellRowHeader">

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
@@ -2,6 +2,7 @@
 @import "src/constants";
 
 $cellWidth: 14rem;
+$bothWidth: 12.5rem;
 $cellHeight: 4rem;
 
 .horizontal-list {
@@ -11,7 +12,7 @@ $cellHeight: 4rem;
 }
 
 .position-container {
-  margin-bottom: 3rem;
+  margin-bottom: 0;
   margin-left: 2rem;
 }
 
@@ -26,7 +27,7 @@ $cellHeight: 4rem;
 .table-container {
   outline-color: $offoffWhite;
   outline-width: 2px;
-  outline-style: dashed;
+  outline-style: solid;
   outline-offset: -1px;
   width: fit-content;
 }
@@ -41,24 +42,55 @@ $cellHeight: 4rem;
   margin: 0;
   overflow-x: hidden;
   overflow-y: hidden;
-  padding: 1em;
+  padding: 1.2em;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: $cellWidth;
   &ColHeader {
+    padding-top: 1.45rem;
     color: $gray;
     font-size: large;
     font-weight: bold;
     vertical-align: middle;
   }
   &RowHeader {
+    padding-top: 1.45rem;
+    padding-left: 2rem;
     color: $gray;
     font-size: large;
     font-weight: bold;
     vertical-align: middle;
   }
   &BothHeader {
+    padding-top: 1.4rem;
+    padding-left: 1rem;
+    color: $black;
+    font-size: 1.4em;
+    font-weight: bold;
+    vertical-align: middle;
+    width: $bothWidth;
   }
+}
+
+.dancer-count-buttons-container {
+  background: $offWhite;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 1.5rem;
+}
+.dancer-count-button {
+  background: $offWhite;
+  height: 2rem;
+  width: 1rem;
+  min-height: 5px!important;
+}
+
+.dancer-count-icon {
+  font-size: 1rem;
+  height: 1rem;
+  width: 1rem;
+  line-height:1rem;
 }
 
 .name-input {
@@ -81,7 +113,7 @@ $cellHeight: 4rem;
 
 .empty-cell {
   border-color: $offoffWhite;
-  border-style: dashed;
+  border-style: solid;
   // @styleIngore Left must come after style by CSS standards
   border-left: none;
   border-top: none;
@@ -104,10 +136,10 @@ $cellHeight: 4rem;
 .export-button {
   background: $offWhite;
   border-radius: $borderRadius;
-  height: 6vh;
+  height: 4vh;
   margin-right: 2rem;
-  margin-top: 2rem;
-  width: 6vh;
+  margin-top: 1.5rem;
+  width: 4vh;
 }
 .export-button-icon {
   font-size: 2.5rem;
@@ -151,7 +183,6 @@ $cellHeight: 4rem;
 
 .save-delete-button-icon {
   color: $gray;
-  // color: rgba(0, 0, 0, 0);
   background: $AAOrange;
   background-clip: text;
   font-size: 3rem;
@@ -163,7 +194,7 @@ $cellHeight: 4rem;
 
 .user-image {
   border-radius: 50%;
-  height: 100%;
+  height: 2.2rem;
   margin-left: 0;
   margin-right: 0.6em;
 }

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
@@ -79,12 +79,6 @@ $cellHeight: 4rem;
   align-items: center;
   width: 1.5rem;
 }
-.dancer-count-button {
-  background: $offWhite;
-  height: 2rem;
-  width: 1rem;
-  min-height: 5px!important;
-}
 
 .dancer-count-icon {
   font-size: 1rem;

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
@@ -79,7 +79,12 @@ $cellHeight: 4rem;
   align-items: center;
   width: 1.5rem;
 }
-
+.dancer-count-button {
+  background: $offWhite;
+  height: 2rem;
+  width: 1rem;
+  min-height: 2px;
+}
 .dancer-count-icon {
   font-size: 1rem;
   height: 1rem;

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -164,7 +164,7 @@ export class CastDragAndDrop implements OnInit {
         for (let subCastIx = 0; subCastIx < subCasts.length; subCastIx++) {
           for (let dancerIx = 0; dancerIx < uiPos.castSize; dancerIx++) {
             const dancer = uiPos.castRows[dancerIx].subCastDancers[subCastIx];
-            if (dancer !== undefined) {
+            if (dancer) {
               subCasts[subCastIx].members.push({
                 uuid: dancer.uuid,
                 position_number: dancerIx,
@@ -185,16 +185,13 @@ export class CastDragAndDrop implements OnInit {
     if (!this.castSelected) {
       return;
     }
+    this.castPositions = [];
     if (!this.castAPI.hasCast(this.selectedCastUUID)) {
-      //this.data = [[]];
-      this.castPositions = [];
       this.castSelected = false;
       this.logging.logError("Couldn't find cast: " + this.selectedCastUUID);
       return;
     }
-
     this.cast = this.castAPI.castFromUUID(this.selectedCastUUID);
-    this.castPositions = [];
     const positions = this.pieceAPI.pieces.get(this.cast.segment).positions;
     for (let positionIx = 0; positionIx < positions.length; positionIx++) {
       const position = positions[positionIx];
@@ -211,12 +208,12 @@ export class CastDragAndDrop implements OnInit {
     this.castPositions = this.castPositions.sort((a, b) => a.pos.order < b.pos.order ? -1 : 1 );
     // Sort positions inside cast
     this.cast.filled_positions = this.cast.filled_positions
-    .filter(val => this.castPositions.find(castPos => castPos.pos.uuid == val.position_uuid))
-    .sort((a, b) => {
-      const castPositionOrderA = this.castPositions.find(castPos => castPos.pos.uuid == a.position_uuid).pos.order;
-      const castPositionOrderB = this.castPositions.find(castPos => castPos.pos.uuid == b.position_uuid).pos.order;
-      return castPositionOrderA < castPositionOrderB ? -1 : 1
-    });
+      .filter(val => this.castPositions.find(castPos => castPos.pos.uuid == val.position_uuid))
+      .sort((a, b) => {
+        const castPositionOrderA = this.castPositions.find(castPos => castPos.pos.uuid == a.position_uuid).pos.order;
+        const castPositionOrderB = this.castPositions.find(castPos => castPos.pos.uuid == b.position_uuid).pos.order;
+        return castPositionOrderA < castPositionOrderB ? -1 : 1
+      });
 
     for (let posIx = 0; posIx < this.cast.filled_positions.length; posIx++) {
       const filledPos = this.cast.filled_positions[posIx];

--- a/frontend/rolecall/src/app/mocks/mock_piece_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_piece_backend.ts
@@ -8,7 +8,25 @@ import { AllPiecesResponse, OnePieceResponse, Piece } from '../api/piece_api.ser
 export class MockPieceBackend {
 
   /** Mock piece database */
-  mockPieceDB: Piece[] = [{ "uuid": "212", "name": "Ode", "type": "SEGMENT", "positions": [{ "id": 213, "name": "Dancer", "notes": "", "order": 0, "size": null, "uuid": "213" }], "deletePositions": [] }, { "uuid": "214", "name": "Divining", "type": "SEGMENT", "positions": [{ "id": 216, "name": "Resting and Moving On", "notes": "", "order": 0, "size": null, "uuid": "216" }, { "id": 215, "name": "Seeking, Resting, and Moving On", "notes": "", "order": 1, "size": null, "uuid": "215" }, { "id": 217, "name": "Moving On", "notes": "", "order": 2, "size": null, "uuid": "217" }], "deletePositions": [] }, { "uuid": "220", "name": "Greenwood", "type": "SEGMENT", "positions": [{ "id": 221, "name": "Witness", "notes": "", "order": 0, "size": null, "uuid": "221" }, { "id": 222, "name": "Sara Page", "notes": "", "order": 1, "size": null, "uuid": "222" }, { "id": 223, "name": "Dick Rowland", "notes": "", "order": 2, "size": null, "uuid": "223" }, { "id": 226, "name": "Son", "notes": "", "order": 3, "size": null, "uuid": "226" }, { "id": 227, "name": "Daughter", "notes": "", "order": 4, "size": null, "uuid": "227" }, { "id": 225, "name": "Mother", "notes": "", "order": 5, "size": null, "uuid": "225" }, { "id": 224, "name": "Father", "notes": "", "order": 6, "size": null, "uuid": "224" }, { "id": 228, "name": "White Psyche", "notes": "", "order": 7, "size": null, "uuid": "228" }], "deletePositions": [] }, { "uuid": "247", "name": "Fandango", "type": "SEGMENT", "positions": [{ "id": 248, "name": "Dancer - Fandango", "notes": "", "order": 0, "size": null, "uuid": "248" }], "deletePositions": [] }, { "uuid": "358", "type": "SEGMENT", "name": "Ella", "positions": [{ "id": 359, "name": "Dancer - Ella", "notes": "", "order": 0, "size": null, "uuid": "359" }], "deletePositions": [] }];
+  mockPieceDB: Piece[] = [{ "uuid": "212", "name": "Ode", "siblingId": null,"type": "SEGMENT", "positions":
+      [{ "id": 213, "name": "Dancer", "notes": "", "order": 0, "siblingId": null, "size": null, "uuid": "213" }],
+      "deletePositions": [] }, { "uuid": "214", "name": "Divining", "siblingId": null, "type": "SEGMENT", "positions":
+      [{ "id": 216, "name": "Resting and Moving On", "notes": "", "order": 0, "siblingId": null, "size": null, "uuid": "216" },
+      { "id": 215, "name": "Seeking, Resting, and Moving On", "notes": "", "order": 1, "siblingId": null, "size": null, "uuid": "215" },
+      { "id": 217, "name": "Moving On", "notes": "", "order": 2, "siblingId": null, "size": null, "uuid": "217" }], "deletePositions": [] },
+      { "uuid": "220", "name": "Greenwood", "siblingId": null, "type": "SEGMENT", "positions":
+      [{ "id": 221, "name": "Witness", "notes": "", "order": 0, "siblingId": null, "size": null, "uuid": "221" },
+      { "id": 222, "name": "Sara Page", "notes": "", "order": 1, "siblingId": null, "size": null, "uuid": "222" },
+      { "id": 223, "name": "Dick Rowland", "notes": "", "order": 2, "siblingId": null, "size": null, "uuid": "223" },
+      { "id": 226, "name": "Son", "notes": "", "order": 3, "siblingId": null, "size": null, "uuid": "226" },
+      { "id": 227, "name": "Daughter", "notes": "", "order": 4, "siblingId": null, "size": null, "uuid": "227" },
+      { "id": 225, "name": "Mother", "notes": "", "order": 5, "siblingId": null, "size": null, "uuid": "225" },
+      { "id": 224, "name": "Father", "notes": "", "order": 6, "siblingId": null, "size": null, "uuid": "224" },
+      { "id": 228, "name": "White Psyche", "notes": "", "order": 7, "siblingId": null, "size": null, "uuid": "228" }], "deletePositions": [] },
+      { "uuid": "247", "name": "Fandango", "siblingId": null, "type": "SEGMENT", "positions":
+      [{ "id": 248, "name": "Dancer - Fandango", "notes": "", "order": 0, "siblingId": null, "size": null, "uuid": "248" }],
+      "deletePositions": [] }, { "uuid": "358", "siblingId": null, "type": "SEGMENT", "name": "Ella", "positions":
+      [{ "id": 359, "name": "Dancer - Ella", "notes": "", "order": 0, "siblingId": null, "size": null, "uuid": "359" }], "deletePositions": [] }];
   shouldRejectSetRequest = false;
 
   /** Mocks backend response */

--- a/frontend/rolecall/src/app/piece/piece.module.ts
+++ b/frontend/rolecall/src/app/piece/piece.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatSelectModule } from '@angular/material/select';
 import { CommonComponentsModule } from '../common_components/common_components.module';
 import { PieceEditor } from './piece_editor.component';
@@ -17,6 +18,7 @@ import { PieceEditor } from './piece_editor.component';
     MatButtonModule,
     CommonComponentsModule,
     MatIconModule,
+    MatMenuModule,
     DragDropModule,
     MatFormFieldModule,
     MatSelectModule

--- a/frontend/rolecall/src/app/piece/piece_editor.component.html
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.html
@@ -8,18 +8,30 @@
       <div class="piece-select-container">
         <div *ngFor="let piece of renderingPieces" class="app-card piece-select"
           [ngClass]="piece.uuid == currentSelectedPiece.uuid ? 'selected-piece' : ''" (click)="setCurrentPiece(piece)">
-          <h2 class="piece-name">
-            {{ piece.name }}
-          </h2>
+            <div *ngIf="piece.type === 'REVELATION'; else otherSegments">
+              <h2 class="piece-name piece-underline">
+                {{ piece.name }}
+              </h2>
+            </div>
+            <ng-template #otherSegments>
+              <h2 class="piece-name" [ngStyle]="{'font-style':piece.siblingId > 0 ? 'italic' : 'normal' }">
+                {{ piece.name }}
+              </h2>
+            </ng-template>
         </div>
       </div>
       <div class="add-button-width-container-left">
         <div class="add-button-height-container-left">
-          <button mat-icon-button aria-label="Add Piece Button" class="add-button" (click)="addPiece()">
+          <button mat-icon-button aria-label="Add Piece Button" class="add-button" [matMenuTriggerFor]="addMenu">
             <mat-icon [inline]="true" class="add-button-icon">
               add
             </mat-icon>
           </button>
+          <mat-menu #addMenu="matMenu">
+            <button mat-menu-item class="rcmitem" (click)="addPiece(1)">Create Segment</button>
+            <button mat-menu-item class="rcmitem" (click)="addPiece(2)">Create Ballet</button>
+            <button mat-menu-item class="rcmitem" (click)="addPiece(3)">Create Revelation</button>
+          </mat-menu>
         </div>
       </div>
     </div>
@@ -28,58 +40,63 @@
   <div class="right-panel">
     <div *ngIf="renderingPieces && renderingPieces.length > 0" class="app-card card-margins right-card">
       <div *ngIf="currentSelectedPiece">
-        <div class="right-title-edit">
-          <input type="text" class="name-input right-card-title app-card" (input)="onTitleInput($event)"
-            [size]="(((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)['length'] < 15)
-                ? 15 : ((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)['length']"
-            [value]="((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)" />
+        <div>
+          <div class="right-title-edit">
+            <input type="text" class="name-input right-card-title app-card" (input)="onTitleInput($event)"
+              [size]="(((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)['length'] < 15)
+                  ? 15 : ((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)['length']"
+              [value]="((currentSelectedPiece | emptyStringIfUndefined)['name'] | emptyStringIfUndefined)" />
+          </div>
+          <div class="right-top-comment">
+            <h2>{{ segmentPrettyNames[currentType] }}</h2>
+          </div>
         </div>
-        <mat-form-field appearance="fill" class="type-dropdown">
-          <mat-label>Segment Type</mat-label>
-          <mat-select [(value)]="selectedSegmentType" (selectionChange)="onSelectSegmentType($event)">
-            <mat-option *ngFor="let type of segmentTypes; let i = index" [value]="type">
-              {{ segmentPrettyNames[i] }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
       </div>
 
-      <div *ngIf="currentSelectedPiece && currentSelectedPiece.type == 'PIECE'" class="app-card positions-card">
+      <div *ngIf="currentSelectedPiece && (currentSelectedPiece.type == 'PIECE' || currentSelectedPiece.type == 'REVELATION')" class="app-card positions-card">
         <div cdkDropList cdkDropListOrientation="vertical" (cdkDropListDropped)="drop($event)" id="position-pool">
           <div *ngIf="currentSelectedPiece">
             <div *ngFor="let data of dragAndDropData; let i = index">
-              <div *ngIf="data.type == 'added'; else addingPosition">
+              <div *ngIf="data.type == 'added'; else addingAndEditingPosition">
                 <div cdkDrag class="position-container">
                   <div class="app-card position-name-card">
-                    <h2 class="position-name">{{ data.value.name }}</h2>
+                    <h2 class="position-name" [ngStyle]="{'font-style':data.value.siblingId > 0 ? 'italic' : 'normal' }">
+                      {{ data.nameDisplay }}
+                    </h2>
+                    <h2 class="position-size">{{ data.sizeDisplay }}</h2>
                   </div>
                   <div class="add-button-height-container">
-                    <button mat-icon-button aria-label="Edit Position Button" class="add-narrow-button"
+                    <button mat-icon-button aria-label="Edit Position Button" class="narrow-button"
                       (click)="editPosition(data.index)">
-                      <mat-icon [inline]="true" class="add-button-icon">
+                      <mat-icon [inline]="true" class="narrow-button-icon">
                         create
                       </mat-icon>
                     </button>
-                    <button mat-icon-button aria-label="Delete Position Button" class="add-narrow-button"
+                    <button mat-icon-button aria-label="Delete Position Button" class="narrow-button"
                       (click)="deletePosition(data.index)">
-                      <mat-icon [inline]="true" class="add-button-icon">
+                      <mat-icon [inline]="true" class="narrow-button-icon">
                         delete
                       </mat-icon>
                     </button>
-                </div>
+                  </div>
                 </div>
               </div>
-              <ng-template #addingPosition>
+              <ng-template #addingAndEditingPosition>
                 <div cdkDrag class="adding-position-container">
-                  <div class="adding-position-input-container">
+                  <div class="adding-position-name-container" [ngStyle]="{'width':currentSelectedPiece.type === 'PIECE' ? '70%' : '100%' }">
                     <app-text-input (valueChange)="onInputChange($event, data)" [bgColor]="offWhite"
                       [valueName]="data.valueName" [initValue]="data.value.name">
                     </app-text-input>
                   </div>
+                  <div *ngIf="currentSelectedPiece.type === 'PIECE'" class="adding-position-size-container">
+                    <app-text-input (valueChange)="onInputChange($event, data)" [bgColor]="offWhite"
+                      [valueName]="sizeValueName" [initValue]="data.value.size">
+                    </app-text-input>
+                  </div>
                   <div class="add-button-height-container">
-                    <button mat-icon-button aria-label="Delete Position Button" class="add-narrow-button"
+                    <button mat-icon-button aria-label="Delete Position Button" class="narrow-button"
                       (click)="deleteAddingPosition(data.index)">
-                      <mat-icon [inline]="true" class="add-button-icon">
+                      <mat-icon [inline]="true" class="narrow-button-icon">
                         delete
                       </mat-icon>
                     </button>
@@ -91,8 +108,8 @@
         </div>
         <div class="add-button-width-container-right">
           <div class="add-button-height-container">
-            <button mat-icon-button aria-label="Add Position Button" class="add-narrow-button" (click)="addPosition()">
-              <mat-icon [inline]="true" class="add-button-icon">
+            <button mat-icon-button aria-label="Add Position Button" class="narrow-button" (click)="addPosition()">
+              <mat-icon [inline]="true" class="narrow-button-icon">
                 add
               </mat-icon>
             </button>

--- a/frontend/rolecall/src/app/piece/piece_editor.component.html
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.html
@@ -28,9 +28,9 @@
             </mat-icon>
           </button>
           <mat-menu #addMenu="matMenu">
-            <button mat-menu-item class="rcmitem" (click)="addPiece(1)">Create Segment</button>
-            <button mat-menu-item class="rcmitem" (click)="addPiece(2)">Create Ballet</button>
-            <button mat-menu-item class="rcmitem" (click)="addPiece(3)">Create Revelation</button>
+            <button mat-menu-item class="create-segment-menu-item" (click)="addPiece(1)">Create Segment</button>
+            <button mat-menu-item class="create-segment-menu-item" (click)="addPiece(2)">Create Ballet</button>
+            <button mat-menu-item class="create-segment-menu-item" (click)="addPiece(3)">Create Revelation</button>
           </mat-menu>
         </div>
       </div>

--- a/frontend/rolecall/src/app/piece/piece_editor.component.scss
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.scss
@@ -210,7 +210,6 @@
   font-weight: bold;
   margin-left: 2rem;
   margin-top: 1em;
-  // max-width: 92.5%;
   max-width: 50%;
   padding-bottom: 0.25em;
   padding-left: 0.5em;
@@ -229,7 +228,6 @@
   font-weight: bold;
   margin-left: 2rem;
   margin-top: 1em;
-  // max-width: 92.5%;
   max-width: 20%;
   padding-bottom: 0.25em;
   padding-left: 0.5em;
@@ -305,6 +303,6 @@
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
-.rcmitem {
+.create-segment-menu-item {
   font-size: 1.3rem;
 }

--- a/frontend/rolecall/src/app/piece/piece_editor.component.scss
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.scss
@@ -47,6 +47,9 @@
   overflow-x: hidden;
   white-space: nowrap;
 }
+.piece-underline {
+  text-decoration: underline;
+}
 .selected-piece {
   background-color: $offoffWhite;
 }
@@ -54,7 +57,7 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  min-height: 8.5vh;
+  min-height: 7.5vh;
   width: 96%;
 }
 // Space below the Positions
@@ -69,7 +72,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  max-width: 6vh;
+  max-width: 5vh;
 }
 .add-button-height-container {
   display: flex;
@@ -79,19 +82,22 @@
 .add-button {
   background: $white;
   border-radius: $borderRadius;
-  height: 6vh;
+  height: 5vh;
   margin-right: 1em;
-  width: 6vh;
+  width: 5vh;
 }
 .add-button-icon {
   font-size: 4vh;
 }
-.add-narrow-button {
+.narrow-button {
   background: $white;
   border-radius: $borderRadius;
   margin-right: 0em;
   height: 6vh;
   width: 4vh;
+}
+.narrow-button-icon {
+  font-size: 4vh;
 }
 // Title styling
 .left-card-title {
@@ -171,12 +177,13 @@
   flex-direction: row;
   justify-content: space-between;
   width: 100%;
+  margin-left: -1.05rem;
+}
+.right-top-comment {
+  margin-top: 0rem;
+  margin-left: 2rem;
 }
 
-.edit-title-container {
-  margin: 1em;
-  width: 100%;
-}
 
 // Saved Positions
 .position-container {
@@ -203,7 +210,27 @@
   font-weight: bold;
   margin-left: 2rem;
   margin-top: 1em;
-  max-width: 92.5%;
+  // max-width: 92.5%;
+  max-width: 50%;
+  padding-bottom: 0.25em;
+  padding-left: 0.5em;
+  padding-top: 0.25em;
+  position: relative;
+  &:focus {
+    border: none;
+  }
+}
+
+.size-input {
+  background: none;
+  border: none;
+  color: black;
+  font-size: xx-large;
+  font-weight: bold;
+  margin-left: 2rem;
+  margin-top: 1em;
+  // max-width: 92.5%;
+  max-width: 20%;
   padding-bottom: 0.25em;
   padding-left: 0.5em;
   padding-top: 0.25em;
@@ -217,7 +244,7 @@
 .position-name-card {
   background: $offWhite;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: space-around;
   margin: 1em;
   width: 100%;
@@ -225,15 +252,30 @@
 
 .position-name {
   margin-bottom: auto;
+  margin-left: 0em;
+  padding-left: 0;
+  margin-top: auto;
+  padding-bottom: 0.5em;
+  padding-top: 0.5em;
+  width: 60%;
+}
+
+.position-size {
+  margin-bottom: auto;
   margin-left: 1em;
   margin-top: auto;
   padding-bottom: 0.5em;
   padding-top: 0.5em;
+  width: 20%;
 }
 
-.adding-position-input-container {
+.adding-position-name-container {
   margin: 1em;
-  width: 100%;
+  width: 70%;
+}
+.adding-position-size-container {
+  margin: 1em;
+  width: 25%;
 }
 
 // Edited Positions
@@ -250,6 +292,7 @@
 }
 
 .right-panel {
+  // background: red;
   width: 75%;
 }
 .cdk-drag-animating {
@@ -260,4 +303,8 @@
 }
 #position-pool.cdk-drop-list-dragging .position-container:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.rcmitem {
+  font-size: 1.3rem;
 }

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -5,20 +5,25 @@ import { MatSelectChange } from '@angular/material/select';
 import { ActivatedRoute } from '@angular/router';
 import { Colors } from 'src/constants';
 import { isNullOrUndefined } from 'util';
-import { Piece, PieceApi, Position } from '../api/piece_api.service';
+import { Piece, PieceType, PieceApi, Position } from '../api/piece_api.service';
 import { ResponseStatusHandlerService } from '../services/response-status-handler.service';
+import { APITypes } from 'src/api_types';
+
 
 type DraggablePosition = {
   index: number,
   value: Position,
-  valueName: "New Position" | "Existing Position",
+  valueName: "New Position" | "Existing Position" | "New Ballet" | "Existing Ballet",
   type: "adding" | "added" | "editing",
+  nameDisplay: string,
+  sizeDisplay: string,
 }
 
 type WorkingPiece = Piece & {
   addingPositions: DraggablePosition[],
-  originalName: string
+  originalName: string,
 }
+
 
 @Component({
   selector: 'app-piece-editor',
@@ -32,6 +37,8 @@ export class PieceEditor implements OnInit {
   renderingPieces: WorkingPiece[];
   urlPointingUUID: string;
 
+  sizeValueName = "# Dancers";
+
   prevWorkingState: WorkingPiece;
   workingPiece: WorkingPiece;
   pieceSaved: boolean = true;
@@ -42,6 +49,14 @@ export class PieceEditor implements OnInit {
   offWhite: string = Colors.offWhite;
 
   lastSelectedPieceName: string;
+
+  currentType = 0;
+
+  segmentTypes = ["SEGMENT", "PIECE", "REVELATION"];
+  selectedSegmentType: "SEGMENT" | "PIECE" | "REVELATION";
+  segmentPrettyNames = ["", "Segment", "Ballet", "Revelation"]
+  //selectedSegmentType: "SEGMENT" | "PIECE" | "REVELATION";
+
 
   constructor(private route: ActivatedRoute, private pieceAPI: PieceApi,
     private location: Location, private respHandler: ResponseStatusHandlerService) { }
@@ -117,6 +132,7 @@ export class PieceEditor implements OnInit {
     }
     this.currentSelectedPiece = piece;
     this.urlPointingUUID = piece ? piece.uuid : "";
+    this.currentType = this.getCurrentTypeCode(piece.type);
     if (this.location.path().startsWith("/segment") || this.location.path().startsWith("/piece/")) {
       if (piece) {
         this.location.replaceState("/segment/" + this.urlPointingUUID);
@@ -127,22 +143,52 @@ export class PieceEditor implements OnInit {
     this.selectedSegmentType = this.currentSelectedPiece ? this.currentSelectedPiece.type : "SEGMENT";
   }
 
-  addPiece() {
+  calcNameDisplay(createPosition: boolean, name: string) {
+    return (createPosition ? "" : "Ballet ") + name;
+  }
+
+  calcSizeDisplay(createPosition: boolean, dancerCount: number) {
+    return (createPosition ? `# Dancers = ${dancerCount}` : "");
+  }
+
+  addPiece(pieceTpCd: number) {
     if (this.creatingPiece) {
       return;
+    }
+    let name: string = "TEST";
+    let type: PieceType = "PIECE";
+    let originalName: string = "TEST";
+    this.currentType = pieceTpCd;
+    switch (pieceTpCd) {
+    case 1:
+      name = "New Break";
+      type = "SEGMENT";
+      originalName = "New Break";
+      break;
+    case 2:
+      name = "New Ballet";
+      type = "PIECE";
+      originalName = "New Ballet";
+      break;
+    case 3:
+      name = "New Revelation";
+      type = "REVELATION";
+      originalName = "New Revelation";
+      break;
     }
     this.creatingPiece = true;
     this.prevWorkingState = undefined;
     let newPiece: WorkingPiece = {
       uuid: "segment:" + Date.now(),
-      name: "New Ballet",
+      name: name,
+      siblingId: null, 
       positions: [],
-      type: "PIECE",
-      originalName: "New Ballet",
+      type: type,
+      originalName: originalName,
       addingPositions: [],
-      deletePositions: []
+      deletePositions: [],
     }
-    this.selectedSegmentType = "PIECE";
+    this.selectedSegmentType = type;
     this.currentSelectedPiece = newPiece;
     this.renderingPieces.push(newPiece);
     this.workingPiece = newPiece;
@@ -150,7 +196,6 @@ export class PieceEditor implements OnInit {
     this.dragAndDropData = [];
     this.setCurrentPiece(this.workingPiece);
   }
-
 
   onSavePiece() {
     if (this.currentSelectedPiece && (!this.currentSelectedPiece.name || this.currentSelectedPiece.name == "")) {
@@ -181,13 +226,16 @@ export class PieceEditor implements OnInit {
     });
   }
 
-  deletePiece() {
-    this.prevWorkingState = undefined;
-    this.renderingPieces = this.renderingPieces.filter(val => val.uuid != this.currentSelectedPiece.uuid);
+  async deletePiece() {
+    let successIndicator: APITypes.SuccessIndicator = {successful: false};
     if (!this.creatingPiece) {
-      this.pieceAPI.deletePiece(this.currentSelectedPiece);
+      successIndicator = await this.pieceAPI.deletePiece(this.currentSelectedPiece);
     }
-    this.renderingPieces.length > 0 ? this.setCurrentPiece(this.renderingPieces[0]) : this.setCurrentPiece(undefined);
+    if (successIndicator.successful === true) {
+      this.renderingPieces = this.renderingPieces.filter(val => val.uuid != this.currentSelectedPiece.uuid);
+      this.renderingPieces.length > 0 ? this.setCurrentPiece(this.renderingPieces[0]) : this.setCurrentPiece(undefined);
+    }
+    this.prevWorkingState = undefined;
     this.pieceSaved = true;
     this.creatingPiece = false;
   }
@@ -198,19 +246,24 @@ export class PieceEditor implements OnInit {
       this.workingPiece = this.currentSelectedPiece;
       this.setCurrentPiece(this.workingPiece);
     }
+    const createPosition = this.currentSelectedPiece.type === "PIECE";
     this.creatingPiece = true;
     this.pieceSaved = false;
-    let nextInd = (this.currentSelectedPiece.positions.length + this.currentSelectedPiece.addingPositions.length);
+    const nextInd = (this.currentSelectedPiece.positions.length + this.currentSelectedPiece.addingPositions.length);
+    const name = createPosition ? "New Position" : "New Ballet";
     this.dragAndDropData.push({
       index: nextInd, value: {
-        name: "New Position",
+        name: name,
         uuid: "position:" + Date.now(),
         notes: "",
         order: nextInd,
+        siblingId: null, 
         size: 1
       },
-      valueName: "New Position",
+      valueName: createPosition ? "New Position" : "New Ballet",
       type: "adding",
+      nameDisplay: this.calcNameDisplay(createPosition, name),
+      sizeDisplay: this.calcSizeDisplay(createPosition, 1),
     });
     this.updateDragAndDropData();
   }
@@ -254,10 +307,6 @@ export class PieceEditor implements OnInit {
     this.currentSelectedPiece.name = event.target.value;
   }
 
-  segmentTypes = ["PIECE", "SEGMENT"];
-  segmentPrettyNames = ["Ballet", "Segment"]
-  selectedSegmentType: "SEGMENT" | "PIECE";
-
   onSelectSegmentType(event: MatSelectChange) {
     this.selectedSegmentType = event.value;
     this.currentSelectedPiece.type = event.value;
@@ -278,23 +327,35 @@ export class PieceEditor implements OnInit {
   }
 
   setWorkingPropertyByKey(key: string, name: string, data?: any) {
-    if (key.startsWith("New Position")) {
+    if (key === "New Position" || key === "New Ballet") {
       const found = this.currentSelectedPiece.addingPositions.find(val => val.index == data.index);
       if (found) {
         found.value.name = name;
       }
     }
-    else if (key.startsWith("Existing Position")) {
+    else if (key === "Existing Position" || key === "Existing Ballet") {
       const found = this.currentSelectedPiece.positions.find(val => val.order == data.index);
       if (found) {
         found.name = name;
       }
+    } else if (key == "# Dancers") {
+      const found = this.currentSelectedPiece.positions.find(val => val.order == data.index);
+      if (found) {
+        found.size = Number(name);
+      }
+      if(!found) {
+        const foundNew = this.currentSelectedPiece.addingPositions.find(val => val.index == data.index);
+        if (foundNew) {
+          foundNew.value.size = Number(name);
+        }
+      }
     } else if (key == "New Ballet Name") {
-      this.currentSelectedPiece.name = name;
+        this.currentSelectedPiece.name = name;
     }
   }
 
   updateDragAndDropData(writeThru?: boolean) {
+    const createPosition = this.currentSelectedPiece.type === "PIECE";
     if (!this.currentSelectedPiece) {
       return;
     }
@@ -304,8 +365,10 @@ export class PieceEditor implements OnInit {
         return {
           index: ind,
           value: val,
-          valueName: "Existing Position",
-          type: "added"
+          valueName: createPosition ? "Existing Position" : "Existing Ballet",
+          type: "added",
+          nameDisplay: this.calcNameDisplay(createPosition, val.name),
+          sizeDisplay: this.calcSizeDisplay(createPosition, val.size),
         };
       });
       return;
@@ -318,7 +381,9 @@ export class PieceEditor implements OnInit {
       if (data.type === "added" || data.type === "editing") {
         let struct: DraggablePosition = {
           type: "added",
-          valueName: "Existing Position",
+          nameDisplay: this.calcNameDisplay(createPosition, data.value.name),
+          sizeDisplay: this.calcSizeDisplay(createPosition, data.value.size),
+          valueName: createPosition ? "Existing Position" : "Existing Ballet",
           index: i,
           value: { ...data.value, order: i }
         };
@@ -327,7 +392,9 @@ export class PieceEditor implements OnInit {
       } else {
         const struct: DraggablePosition = {
           type: "adding",
-          valueName: "New Position",
+          nameDisplay: this.calcNameDisplay(createPosition, data.value.name),
+          sizeDisplay: this.calcSizeDisplay(createPosition, data.value.size),
+          valueName: createPosition ? "New Position" : "New Ballet",
           index: i,
           value: { ...data.value, order: i }
         };
@@ -361,5 +428,17 @@ export class PieceEditor implements OnInit {
     }
     transferArrayItem(this.dragAndDropData, this.dragAndDropData, event.previousIndex, event.currentIndex);
     this.pieceSaved = false;
+  }
+
+  getCurrentTypeCode(type: PieceType): number {
+    let code = 0;
+    if (type === "PIECE") {
+      code = 2;
+    } else if (type === "REVELATION") {
+      code = 3;
+    } else if (type === "SEGMENT") {
+      code = 1;
+    }
+    return code;
   }
 }

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -53,9 +53,8 @@ export class PieceEditor implements OnInit {
   currentType = 0;
 
   segmentTypes = ["SEGMENT", "PIECE", "REVELATION"];
-  selectedSegmentType: "SEGMENT" | "PIECE" | "REVELATION";
+  selectedSegmentType: PieceType;
   segmentPrettyNames = ["", "Segment", "Ballet", "Revelation"]
-  //selectedSegmentType: "SEGMENT" | "PIECE" | "REVELATION";
 
 
   constructor(private route: ActivatedRoute, private pieceAPI: PieceApi,

--- a/frontend/rolecall/src/colors.scss
+++ b/frontend/rolecall/src/colors.scss
@@ -7,3 +7,4 @@ $AAOrange: linear-gradient(to right, #f7690a, #ff5927);
 $gray: #6d6d6d;
 $lightGray: #9c9c9c;
 $lightLightGray: #b1b1b1;
+$black: black;


### PR DESCRIPTION
This pull request involves 2 significant changes: 1) a new Cast logic, and 2) beginning support for Revelations (a collection of ballets).
The reason for the new cast logic is that the users found it confusing and started to request changes that didn't make sense given the actual underlying architecture.
The reasons for implementing Revelations now, rather than later as originally planned, is that the customer misunderstood the old cast interface and believed that Revelations were already implemented (however poorly). Because of this, we don't believe we can make the customer happy without supporting Revelations.
1) The new cast logic. Front end changes only, but a very significant rewrite of the cast interface.
The problem with the old interface was that it was too dynamic. You could create almost any cast regardless of the underlying structure. And worse, the old interface indicated that new positions had been created in the Cast interface and the customer was asking us to build out editing capabilities for these imagined new positions.

The new interface is more rigid. # Casts is fixed at 3. # Dancers is based on the Position definition. (This meant that cast size had to be an editable field in the position.) It is possible to override the Positions size definition in the Cast, but it is clear that it is a change of Cast size and that new Positions are not changed.

2) Beginning support for Revelations. Frontend and backend changes.
Just like a Ballet structurally is an ordered collection of Positions, a Revelation is an ordered collection of Ballets. Because of this isomorphism, the Segment interface can be used for both. A complication is that a specific Ballet can now exist in two places: a) as a top-level Ballet (with Position children) and b) as a child of a Revelation. These two "sibling" objects need to be synchronized so that changes made on one transfer over to the other. To make this happen, I added links in both the Piece data structure (Section on the backend) and the Position structure (the new field is called "siblingId" in both structures. This field is null in normal Ballets and Positions, but is not null on Ballets that are also children of Revelations.

All the code changes on the backend are associated with the added siblingId field as well as synchronizing "sibling objects" when these objects are created, edited or deleted.

On the frontend a new level (the Revelations) as well as the new hybrid Ballet/Position objects.

I started working on the Revelations first but when it became clear that our casting interface was a major problem, that became my top priority. As a result, this PR has 1.5 features rather than 1. I apologize for the larger chunk size.