### PR TITLE
Almost only backend changes for revelation support

### DIFF
--- a/backend/src/main/java/com/google/rolecall/ApplicationLoader.java
+++ b/backend/src/main/java/com/google/rolecall/ApplicationLoader.java
@@ -3,9 +3,15 @@ package com.google.rolecall;
 import com.google.rolecall.models.User;
 import com.google.rolecall.repos.UserRepository;
 import com.google.rolecall.restcontrollers.exceptionhandling.RequestExceptions.InvalidParameterException;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -61,6 +67,86 @@ public class ApplicationLoader implements ApplicationRunner {
     userRepo.save(admin);
     logger.log(Level.WARNING, String.format("Admin User Created: %s %s %s", 
         adminFirstName, adminLastName, adminEmail));
+    createTestData();
+  }
+
+  // Create sample data
+  
+  private enum DataCreateError {
+    OK,
+    OtherError
+  }
+
+  private DataCreateError createOneUser(String fName, String lName, String email, String dateJoined) {
+    Calendar cal = Calendar.getInstance();
+    SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy", Locale.US);
+    User user;
+    try {
+      cal.setTime(sdf.parse(dateJoined));
+
+      user = User.newBuilder()
+          .setFirstName(fName)
+          .setLastName(lName)
+          .setEmail(email)
+          .setDateJoined(cal)
+          .setIsActive(true)
+          .setCanLogin(true)
+          .setIsDancer(true)
+          .build();
+      userRepo.save(user);
+    } catch(InvalidParameterException e) {
+      return DataCreateError.OtherError;
+    } catch(ParseException e) {
+      return DataCreateError.OtherError;
+    }
+    return DataCreateError.OK;
+  }
+
+  private DataCreateError createTestData() {
+    logger.log(Level.WARNING, "Creating test data.");    
+    Boolean finished = false;
+    while (!finished) {
+      if(DataCreateError.OK != createOneUser("Robert", "Battle", "rb@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jeroboam", "Bozeman", "bb@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Clifton", "Brown", "cb@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Khalia", "Campbell", "kc@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Patrick", "Coker", "pc@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Sarah", "Daley", "sd@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Ghrai", "Devore", "gde@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Solomon", "Dumas", "sdu@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Ronni", "Favors", "rf@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Samantha", "Figgins", "sf@gmail.com","1/1/2020")) break;
+
+      if(DataCreateError.OK != createOneUser("James", "Gilmer", "jg@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Vernard", "Gilmore", "vg@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jacqueline", "Green", "jgr@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jacquelin", "Harris", "jh@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Michael", "Jackson", "mj@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Yazzmeen", "Laidler", "yl@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Yannick", "Lebrun", "yle@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Constance", "Lopez", "csl@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Renaldo", "Maurice", "rm@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Corrin", "Mitchell", "crm@gmail.com","1/1/2020")) break;
+
+      if(DataCreateError.OK != createOneUser("Chalvar", "Monteiro", "cm@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Belen", "Pereyra", "bp@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jessica", "Pinkett", "jap@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Miranda", "Quinn", "mq@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jamar", "Roberts", "jr@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Matthew", "Rushing", "mr@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Kanji", "Segawa", "ks@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Courtney", "Spears", "ccs@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Jermaine", "Terry", "jt@gmail.com","1/1/2020")) break;
+      if(DataCreateError.OK != createOneUser("Christopher", "Wilson", "cw@gmail.com","1/1/2020")) break;
+
+      if(DataCreateError.OK != createOneUser("Brandon", "Woolridge", "bw@gmail.com","1/1/2020")) break;
+      finished = true;
+    }
+    if(!finished) {
+      logger.log(Level.SEVERE, "Unable to Create Sample Data");
+      return DataCreateError.OtherError;   
+    }
+    return DataCreateError.OK;
   }
 
   @Autowired

--- a/backend/src/main/java/com/google/rolecall/ApplicationLoader.java
+++ b/backend/src/main/java/com/google/rolecall/ApplicationLoader.java
@@ -67,8 +67,12 @@ public class ApplicationLoader implements ApplicationRunner {
     userRepo.save(admin);
     logger.log(Level.WARNING, String.format("Admin User Created: %s %s %s", 
         adminFirstName, adminLastName, adminEmail));
-    createTestData();
+    if(DataCreateError.OK != createTestData()) {
+      logger.log(Level.SEVERE, "Unable to Create Sample Data");
+    }
   }
+
+  // TODO: Remove the sameple data creation once the customer is up and running.
 
   // Create sample data
   
@@ -77,11 +81,12 @@ public class ApplicationLoader implements ApplicationRunner {
     OtherError
   }
 
-  private DataCreateError createOneUser(String fName, String lName, String email, String dateJoined) {
+  private void createOneUser(String fName, String lName, String email, String dateJoined)
+      throws ParseException, InvalidParameterException {
     Calendar cal = Calendar.getInstance();
     SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy", Locale.US);
     User user;
-    try {
+
       cal.setTime(sdf.parse(dateJoined));
 
       user = User.newBuilder()
@@ -94,57 +99,49 @@ public class ApplicationLoader implements ApplicationRunner {
           .setIsDancer(true)
           .build();
       userRepo.save(user);
-    } catch(InvalidParameterException e) {
-      return DataCreateError.OtherError;
-    } catch(ParseException e) {
-      return DataCreateError.OtherError;
-    }
-    return DataCreateError.OK;
   }
 
   private DataCreateError createTestData() {
     logger.log(Level.WARNING, "Creating test data.");    
-    Boolean finished = false;
-    while (!finished) {
-      if(DataCreateError.OK != createOneUser("Robert", "Battle", "rb@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jeroboam", "Bozeman", "bb@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Clifton", "Brown", "cb@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Khalia", "Campbell", "kc@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Patrick", "Coker", "pc@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Sarah", "Daley", "sd@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Ghrai", "Devore", "gde@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Solomon", "Dumas", "sdu@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Ronni", "Favors", "rf@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Samantha", "Figgins", "sf@gmail.com","1/1/2020")) break;
+    try {
+      createOneUser("Robert", "Battle", "rb@gmail.com","1/1/2020");
+      createOneUser("Jeroboam", "Bozeman", "bb@gmail.com","1/1/2020");
+      createOneUser("Clifton", "Brown", "cb@gmail.com","1/1/2020");
+      createOneUser("Khalia", "Campbell", "kc@gmail.com","1/1/2020");
+      createOneUser("Patrick", "Coker", "pc@gmail.com","1/1/2020");
+      createOneUser("Sarah", "Daley", "sd@gmail.com","1/1/2020");
+      createOneUser("Ghrai", "Devore", "gde@gmail.com","1/1/2020");
+      createOneUser("Solomon", "Dumas", "sdu@gmail.com","1/1/2020");
+      createOneUser("Ronni", "Favors", "rf@gmail.com","1/1/2020");
+      createOneUser("Samantha", "Figgins", "sf@gmail.com","1/1/2020");
 
-      if(DataCreateError.OK != createOneUser("James", "Gilmer", "jg@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Vernard", "Gilmore", "vg@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jacqueline", "Green", "jgr@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jacquelin", "Harris", "jh@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Michael", "Jackson", "mj@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Yazzmeen", "Laidler", "yl@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Yannick", "Lebrun", "yle@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Constance", "Lopez", "csl@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Renaldo", "Maurice", "rm@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Corrin", "Mitchell", "crm@gmail.com","1/1/2020")) break;
+      createOneUser("James", "Gilmer", "jg@gmail.com","1/1/2020");
+      createOneUser("Vernard", "Gilmore", "vg@gmail.com","1/1/2020");
+      createOneUser("Jacqueline", "Green", "jgr@gmail.com","1/1/2020");
+      createOneUser("Jacquelin", "Harris", "jh@gmail.com","1/1/2020");
+      createOneUser("Michael", "Jackson", "mj@gmail.com","1/1/2020");
+      createOneUser("Yazzmeen", "Laidler", "yl@gmail.com","1/1/2020");
+      createOneUser("Yannick", "Lebrun", "yle@gmail.com","1/1/2020");
+      createOneUser("Constance", "Lopez", "csl@gmail.com","1/1/2020");
+      createOneUser("Renaldo", "Maurice", "rm@gmail.com","1/1/2020");
+      createOneUser("Corrin", "Mitchell", "crm@gmail.com","1/1/2020");
 
-      if(DataCreateError.OK != createOneUser("Chalvar", "Monteiro", "cm@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Belen", "Pereyra", "bp@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jessica", "Pinkett", "jap@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Miranda", "Quinn", "mq@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jamar", "Roberts", "jr@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Matthew", "Rushing", "mr@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Kanji", "Segawa", "ks@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Courtney", "Spears", "ccs@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Jermaine", "Terry", "jt@gmail.com","1/1/2020")) break;
-      if(DataCreateError.OK != createOneUser("Christopher", "Wilson", "cw@gmail.com","1/1/2020")) break;
+      createOneUser("Chalvar", "Monteiro", "cm@gmail.com","1/1/2020");
+      createOneUser("Belen", "Pereyra", "bp@gmail.com","1/1/2020");
+      createOneUser("Jessica", "Pinkett", "jap@gmail.com","1/1/2020");
+      createOneUser("Miranda", "Quinn", "mq@gmail.com","1/1/2020");
+      createOneUser("Jamar", "Roberts", "jr@gmail.com","1/1/2020");
+      createOneUser("Matthew", "Rushing", "mr@gmail.com","1/1/2020");
+      createOneUser("Kanji", "Segawa", "ks@gmail.com","1/1/2020");
+      createOneUser("Courtney", "Spears", "ccs@gmail.com","1/1/2020");
+      createOneUser("Jermaine", "Terry", "jt@gmail.com","1/1/2020");
+      createOneUser("Christopher", "Wilson", "cw@gmail.com","1/1/2020");
 
-      if(DataCreateError.OK != createOneUser("Brandon", "Woolridge", "bw@gmail.com","1/1/2020")) break;
-      finished = true;
-    }
-    if(!finished) {
-      logger.log(Level.SEVERE, "Unable to Create Sample Data");
-      return DataCreateError.OtherError;   
+      createOneUser("Brandon", "Woolridge", "bw@gmail.com","1/1/2020");
+    } catch(InvalidParameterException e) {
+      return DataCreateError.OtherError;
+    } catch(ParseException e) {
+      return DataCreateError.OtherError;
     }
     return DataCreateError.OK;
   }

--- a/backend/src/main/java/com/google/rolecall/jsonobjects/CastMemberInfo.java
+++ b/backend/src/main/java/com/google/rolecall/jsonobjects/CastMemberInfo.java
@@ -2,11 +2,12 @@ package com.google.rolecall.jsonobjects;
 
 import javax.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+@JsonDeserialize(builder = AutoValue_CastMemberInfo.Builder.class)
 @AutoValue
 public abstract class CastMemberInfo {
   @Nullable
@@ -27,14 +28,42 @@ public abstract class CastMemberInfo {
 
   @Nullable
   @JsonIgnore
+  @JsonProperty("delete")
   public abstract Boolean delete();
 
-  @JsonCreator
-  public static CastMemberInfo create(@Nullable @JsonProperty("id") Integer id, 
-      @Nullable @JsonProperty("userId") Integer userId,
-      @Nullable @JsonProperty("subCastId") Integer subCastId,
-      @Nullable @JsonProperty("order") Integer order,
-      @Nullable @JsonProperty("delete") Boolean delete) {
-    return new AutoValue_CastMemberInfo(id, userId, subCastId, order, delete);
+  @Override
+  public boolean equals(Object object) {
+    return this == object;
   }
+
+  /* Object hashcode */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  public static Builder newBuilder() {
+    return new AutoValue_CastMemberInfo.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    @JsonProperty("id")
+    public abstract Builder setId(Integer id);
+
+    @JsonProperty("userId")
+    public abstract Builder setUserId(Integer userId);
+
+    @JsonProperty("subCastId")
+    public abstract Builder setSubCastId(Integer subCastId);
+
+    @JsonProperty("order")
+    public abstract Builder setOrder(Integer order);
+
+    @JsonProperty("delete")
+    public abstract Builder setDelete(Boolean delete);
+
+    public abstract CastMemberInfo build();
+  }
+  
 }

--- a/backend/src/main/java/com/google/rolecall/jsonobjects/PerformancePositionInfo.java
+++ b/backend/src/main/java/com/google/rolecall/jsonobjects/PerformancePositionInfo.java
@@ -16,6 +16,10 @@ public abstract class PerformancePositionInfo {
   public abstract Integer positionId();
 
   @Nullable
+  @JsonProperty("positionOrder")
+  public abstract Integer positionOrder();
+
+  @Nullable
   @JsonProperty("casts")
   public abstract List<PerformanceCastInfo> performanceCasts();
 
@@ -39,6 +43,9 @@ public abstract class PerformancePositionInfo {
   public abstract static class Builder { 
     @JsonProperty("positionId")
     public abstract Builder setPositionId(Integer positionId);
+
+    @JsonProperty("positionOrder")
+    public abstract Builder setPositionOrder(Integer positionOrder);
 
     @JsonProperty("casts")
     public abstract Builder setPerformanceCasts(List<PerformanceCastInfo> performanceCasts);

--- a/backend/src/main/java/com/google/rolecall/models/CastMember.java
+++ b/backend/src/main/java/com/google/rolecall/models/CastMember.java
@@ -46,12 +46,12 @@ public class CastMember {
 
   public CastMemberInfo toCastMemberInfo() {
     return CastMemberInfo.newBuilder()
-    .setId(id)
-    .setUserId(user.getId())
-    .setSubCastId(cast.getId())
-    .setOrder(order)
-    .setDelete(null)
-    .build();
+        .setId(id)
+        .setUserId(user.getId())
+        .setSubCastId(cast.getId())
+        .setOrder(order)
+        .setDelete(null)
+        .build();
   }
 
   public void setOrder(Integer order) {

--- a/backend/src/main/java/com/google/rolecall/models/CastMember.java
+++ b/backend/src/main/java/com/google/rolecall/models/CastMember.java
@@ -45,7 +45,13 @@ public class CastMember {
   }
 
   public CastMemberInfo toCastMemberInfo() {
-    return CastMemberInfo.create(id, user.getId(), cast.getId(), order, null);
+    return CastMemberInfo.newBuilder()
+    .setId(id)
+    .setUserId(user.getId())
+    .setSubCastId(cast.getId())
+    .setOrder(order)
+    .setDelete(null)
+    .build();
   }
 
   public void setOrder(Integer order) {

--- a/backend/src/main/java/com/google/rolecall/models/PerformanceSection.java
+++ b/backend/src/main/java/com/google/rolecall/models/PerformanceSection.java
@@ -143,7 +143,7 @@ public class PerformanceSection {
   private List<PerformancePositionInfo> toAllPerformancePositionInfo(
       Hashtable<Integer, Hashtable<Integer, List<PerformanceCastMemberInfo>>> positions,
       Hashtable<Integer, Integer> positionOrders) {
-  List<PerformancePositionInfo> positionInfos = new ArrayList<>();
+    List<PerformancePositionInfo> positionInfos = new ArrayList<>();
 
     for(Integer positionId: positions.keySet()) {
       Hashtable<Integer, List<PerformanceCastMemberInfo>> casts = positions.get(positionId);

--- a/backend/src/main/java/com/google/rolecall/models/PerformanceSection.java
+++ b/backend/src/main/java/com/google/rolecall/models/PerformanceSection.java
@@ -103,8 +103,10 @@ public class PerformanceSection {
     Hashtable<Integer, Hashtable<Integer, List<PerformanceCastMemberInfo>>> positions = 
         new Hashtable<>();
     
+    Hashtable<Integer, Integer> positionOrders = new Hashtable<>();
     for(PerformanceCastMember member: performanceCastMembers) {
       Integer positionId = member.getPosition().getId();
+      Integer positionOrder = member.getPosition().getOrder();
 
       Hashtable<Integer, List<PerformanceCastMemberInfo>> cast;
       if(positions.containsKey(positionId)) {
@@ -112,6 +114,7 @@ public class PerformanceSection {
       } else {
         cast = new Hashtable<>();
         positions.put(positionId, cast);
+        positionOrders.put(positionId, positionOrder);
       }
 
       int castNumber = member.getCastNumber();
@@ -126,7 +129,7 @@ public class PerformanceSection {
       members.add(member.toPerformanceCastMemberInfo());
     }
 
-    List<PerformancePositionInfo> positionInfos = toAllPerformancePositionInfo(positions);
+    List<PerformancePositionInfo> positionInfos = toAllPerformancePositionInfo(positions, positionOrders);
 
     return PerformanceSectionInfo.newBuilder()
         .setId(id)
@@ -138,8 +141,9 @@ public class PerformanceSection {
   }
 
   private List<PerformancePositionInfo> toAllPerformancePositionInfo(
-      Hashtable<Integer, Hashtable<Integer, List<PerformanceCastMemberInfo>>> positions) {
-    List<PerformancePositionInfo> positionInfos = new ArrayList<>();
+      Hashtable<Integer, Hashtable<Integer, List<PerformanceCastMemberInfo>>> positions,
+      Hashtable<Integer, Integer> positionOrders) {
+  List<PerformancePositionInfo> positionInfos = new ArrayList<>();
 
     for(Integer positionId: positions.keySet()) {
       Hashtable<Integer, List<PerformanceCastMemberInfo>> casts = positions.get(positionId);
@@ -156,6 +160,7 @@ public class PerformanceSection {
       
       PerformancePositionInfo positionInfo = PerformancePositionInfo.newBuilder()
           .setPositionId(positionId)
+          .setPositionOrder(positionOrders.get(positionId))
           .setPerformanceCasts(castInfos)
           .build();
 

--- a/backend/src/main/java/com/google/rolecall/services/PerformanceServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/PerformanceServices.java
@@ -202,7 +202,7 @@ public class PerformanceServices {
     User user = userService.getUser(memberInfo.userId());
 
     PerformanceCastMember member = PerformanceCastMember.newBuilder()
-        .setOrder(position.getOrder())
+        .setOrder(memberInfo.order())
         .setCastNumber(castNumber)
         .build();
     
@@ -359,11 +359,6 @@ public class PerformanceServices {
         } else {
           orders = new HashSet<>();
           positionOrders.put(castNumber, orders);
-        }
-
-        if(orders.contains(member.getOrder())) {
-          throw new InvalidParameterException(
-            "Each Cast Member must have an order unique to cast number and Position");
         }
         orders.add(member.getOrder());
 

--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -309,17 +309,18 @@ public class SectionServices {
     if(isParentRevelation) {
       // Update sibling Ballets with ids of Revelation's internal Ballet/Position structures
       for(int loopCounter = 0; loopCounter < section.getPositions().size(); loopCounter++) {
-        Position pos = section.getPositions().get(loopCounter);
-  
-        Section subSection = Section.newBuilder()
-            .setId(siblingIndexArray[loopCounter])
-            .setName(pos.getName())
-            .setNotes("")
-            .setLength(0)
-            .setSiblingId(pos.getId())
-            .setType(Section.Type.PIECE)
-            .build();
-        sectionRepo.save(subSection);
+        if(siblingIndexArray[loopCounter] != -1) {
+          Position pos = section.getPositions().get(loopCounter);
+          Section subSection = Section.newBuilder()
+              .setId(siblingIndexArray[loopCounter])
+              .setName(pos.getName())
+              .setNotes("")
+              .setLength(0)
+              .setSiblingId(pos.getId())
+              .setType(Section.Type.PIECE)
+              .build();
+          sectionRepo.save(subSection);
+        }
       }
     }
   }

--- a/frontend/rolecall/src/app/api/performance-api.service.ts
+++ b/frontend/rolecall/src/app/api/performance-api.service.ts
@@ -66,6 +66,7 @@ export type RawPerformance = {
     "positions":
     {
       "positionId": number,
+      "positionOrder": number,
       "casts":
       {
         "castNumber": number,
@@ -143,14 +144,14 @@ export class PerformanceApi {
             segment: String(val.sectionId),
             length: 0,
             selected_group: val.primaryCast,
-            custom_groups: val.positions.map(pos => {
+            custom_groups: val.positions.map((position, positionIx) => {
               return {
-                position_uuid: String(pos.positionId),
-                position_order: pos.casts[0].members[0].order,
-                groups: pos.casts.map(c => {
+                position_uuid: String(position.positionId),
+                position_order: position.positionOrder,
+                groups: position.casts.map((sumCast, subCastIx) => {
                   return {
-                    group_index: c.castNumber,
-                    members: c.members.map(mem => {
+                    group_index: sumCast.castNumber,
+                    members: sumCast.members.map(mem => {
                       return {
                         uuid: String(mem.userId),
                         position_number: mem.order
@@ -158,7 +159,6 @@ export class PerformanceApi {
                     })
                   }
                 })
-
               }
             })
           }
@@ -184,23 +184,24 @@ export class PerformanceApi {
       state: perf.step_1.state,
       dateTime: perf.step_1.date,
       status: perf.status ? perf.status : PerformanceStatus.DRAFT,
-      performanceSections: perf.step_3.segments.map((seg, ind) => {
+      performanceSections: perf.step_3.segments.map((seg, segIx) => {
         return {
           id: seg.id ? Number(seg.id) : undefined,
-          sectionPosition: ind,
+          sectionPosition: segIx,
           primaryCast: seg.selected_group,
           sectionId: Number(seg.segment),
-          positions: seg.custom_groups.map(cg => {
+          positions: seg.custom_groups.map((customGroup, customGroupIx) => {
             return {
-              positionId: Number(cg.position_uuid),
-              casts: cg.groups.map(c => {
+              positionId: Number(customGroup.position_uuid),
+              positionOrder: customGroup.position_order,
+              casts: customGroup.groups.map((subCast, subCastIx) => {
                 return {
-                  castNumber: c.group_index,
-                  members: c.members.map(mem => {
+                  castNumber: subCast.group_index,
+                  members: subCast.members.map(mem => {
                     return {
                       order: mem.position_number,
                       userId: Number(mem.uuid),
-                      performing: c.group_index == seg.selected_group
+                      performing: subCast.group_index == seg.selected_group
                     }
                   })
                 }


### PR DESCRIPTION
These are the backend changes made to enable support for 'revelations'. The only frontend file included is the file that reads the performances, where a data field had to be added.

In ApplicationLoader.java I added sample data (the Alvin Ailey users are added whenever the database is empty. In order to give them a starting data, I had to add some date parsing code.)

When I added the positionOrder field in /jsonobjects/PerformancePositionInfo.java, I got a syntax error in /jsonobjects/CastMemberInfo.java that I couldn't figure out how to get rid of. I never liked the different structure of the old CastMemberInfo file anyway, so I rewrote it using a standard builder pattern. Because of this, I also had to change the builder call in models/CastMember.java.

The other changes are logic changes necessary store and read revelations.
