### PR TITLE
Frontend changes for revelation support

### DIFF
--- a/frontend/rolecall/src/app/api/user_api.service.ts
+++ b/frontend/rolecall/src/app/api/user_api.service.ts
@@ -40,7 +40,7 @@ interface rawUser {
   isDancer: boolean;
   isOther: boolean;
   canLogin: boolean;
-  canReceiveNotifications: boolean;
+  notifications: boolean;
   managePerformances: boolean;
   manageCasts: boolean;
   managePieces: boolean;
@@ -120,7 +120,7 @@ export class UserApi {
               },
               has_permissions: {
                 canLogin: val.canLogin,
-                canReceiveNotifications: val.canReceiveNotifications,
+                canReceiveNotifications: val.notifications,
                 managePerformances: val.managePerformances,
                 manageCasts: val.manageCasts,
                 managePieces: val.managePieces,

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -190,7 +190,8 @@ export class CastDragAndDrop implements OnInit {
     this.castPositions = [];
     if (!this.castAPI.hasCast(this.selectedCastUUID)) {
       this.castSelected = false;
-      this.logging.logError("Couldn't find cast: " + this.selectedCastUUID);
+      // The below error means little. After any save the system loses tracf the uuid of the saved cast
+      // this.logging.logError("Couldn't find cast: " + this.selectedCastUUID);
       return;
     }
     this.cast = this.castAPI.castFromUUID(this.selectedCastUUID);
@@ -223,7 +224,6 @@ export class CastDragAndDrop implements OnInit {
       let maxDancerIx = 0;
       for (let groupIx = 0; groupIx < filledPos.groups.length; groupIx++) {
         const group = filledPos.groups[groupIx];
-        const group_index = group.group_index;
         for (let memberIx = 0; memberIx < group.members.length; memberIx++) {
           const member = group.members[memberIx];
           if (member.position_number >= maxDancerIx) {
@@ -235,7 +235,7 @@ export class CastDragAndDrop implements OnInit {
             }
           }
           const dancer = this.userAPI.users.get(member.uuid);
-          uiPos.castRows[member.position_number].subCastDancers[group_index] = {
+          uiPos.castRows[member.position_number].subCastDancers[group.group_index] = {
             uuid: dancer.uuid,
             firstName: dancer.first_name,
             lastName: dancer.last_name,

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -190,8 +190,7 @@ export class CastDragAndDrop implements OnInit {
     this.castPositions = [];
     if (!this.castAPI.hasCast(this.selectedCastUUID)) {
       this.castSelected = false;
-      // The below error means little. After any save the system loses tracf the uuid of the saved cast
-      // this.logging.logError("Couldn't find cast: " + this.selectedCastUUID);
+      // TODO: After any save the system loses track the uuid of the saved cast. It would be nice to fix [YHE].
       return;
     }
     this.cast = this.castAPI.castFromUUID(this.selectedCastUUID);

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
@@ -16,11 +16,11 @@
           </mat-icon>
           <div ngbDropdownMenu
               class="piece-options"
-              aria-labelledby="Piece Dropdown">
+              aria-label="Piece Dropdown">
             <button *ngFor="let piece of popupPieceList"
                 ngbDropdownItem
                [class.std-italic-font]="piece.hasSibling"
-               (click)="selectPiece(piece.pieceIx)">
+               (click)="selectPiece(piece.pieceIndex)">
               {{piece.name}}
             </button>
           </div>

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
@@ -8,7 +8,7 @@
         <div ngbDropdownToggle
             class="app-card piece-select">
           <h1 class="left-card-title"
-              [ngStyle]="{'font-style': selectedPiece && selectedPiece.siblingId > 0 ? 'italic' : 'normal' }">
+              [class.std-italic-font]="selectedPiece && selectedPiece.siblingId > 0">
             {{selectedPiece ? selectedPiece.name : " "}}
           </h1>
           <mat-icon class="dropdownArrow">
@@ -17,10 +17,10 @@
           <div ngbDropdownMenu
               class="piece-options"
               aria-labelledby="Piece Dropdown">
-            <button *ngFor="let piece of popupList"
+            <button *ngFor="let piece of popupPieceList"
                 ngbDropdownItem
-                (click)="onSelectPiece(piece.pieceIx)"
-                [ngStyle]="{'font-style': piece.hasSibling ? 'italic' : 'normal' }">
+               [class.std-italic-font]="piece.hasSibling"
+               (click)="selectPiece(piece.pieceIx)">
               {{piece.name}}
             </button>
           </div>
@@ -29,10 +29,10 @@
       <div class="cast-select-container">
         <div *ngFor="let cast of filteredCasts"
             class="app-card cast-select"
-            [ngClass]="cast.uuid == castDragAndDrop.selectedCastUUID ? 'selected-cast' : ''"
+            [class.selected-cast]="cast.uuid == castDragAndDrop.selectedCastUUID"
             (click)="setCurrentCast(cast)">
           <h2 class="cast-name"
-              [ngStyle]="{'font-style': selectedPiece && selectedPiece.siblingId > 0 ? 'italic' : 'normal' }">
+              [class.std-italic-font]="selectedPiece && selectedPiece.siblingId > 0">
             {{ cast.name }}
           </h2>
         </div>

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
@@ -1,34 +1,48 @@
 <app-loading-spinner *ngIf="!dataLoaded"></app-loading-spinner>
-<div [ngStyle]="dataLoaded ? {} : { 'display' : 'none' }" class="root-container">
+<div class="root-container"
+    [ngStyle]="dataLoaded ? {} : { 'display' : 'none' }">
   <div class="cast-selector-container">
     <div class="app-card card-margins left-card">
-      <div ngbDropdown #pieceDropdown="ngbDropdown">
-        <div class="app-card piece-select" ngbDropdownToggle>
-          <h1 class="left-card-title">
+      <div ngbDropdown
+          #pieceDropdown="ngbDropdown">
+        <div ngbDropdownToggle
+            class="app-card piece-select">
+          <h1 class="left-card-title"
+              [ngStyle]="{'font-style': selectedPiece && selectedPiece.siblingId > 0 ? 'italic' : 'normal' }">
             {{selectedPiece ? selectedPiece.name : " "}}
           </h1>
           <mat-icon class="dropdownArrow">
             arrow_drop_down
           </mat-icon>
-          <div ngbDropdownMenu aria-labelledby="Piece Dropdown" class="piece-options">
-            <button ngbDropdownItem *ngFor="let piece of allPieces" (click)="onSelectPiece(piece)">
+          <div ngbDropdownMenu
+              class="piece-options"
+              aria-labelledby="Piece Dropdown">
+            <button *ngFor="let piece of popupList"
+                ngbDropdownItem
+                (click)="onSelectPiece(piece.pieceIx)"
+                [ngStyle]="{'font-style': piece.hasSibling ? 'italic' : 'normal' }">
               {{piece.name}}
             </button>
           </div>
         </div>
       </div>
       <div class="cast-select-container">
-        <div *ngFor="let cast of filteredCasts" class="app-card cast-select"
-          [ngClass]="cast.uuid == castDragAndDrop.selectedCastUUID ? 'selected-cast' : ''"
-          (click)="setCurrentCast(cast)">
-          <h2 class="cast-name">
+        <div *ngFor="let cast of filteredCasts"
+            class="app-card cast-select"
+            [ngClass]="cast.uuid == castDragAndDrop.selectedCastUUID ? 'selected-cast' : ''"
+            (click)="setCurrentCast(cast)">
+          <h2 class="cast-name"
+              [ngStyle]="{'font-style': selectedPiece && selectedPiece.siblingId > 0 ? 'italic' : 'normal' }">
             {{ cast.name }}
           </h2>
         </div>
       </div>
       <div class="add-button-width-container">
         <div class="add-button-height-container">
-          <button mat-icon-button aria-label="Add Cast Button" class="add-button" (click)="addCast()">
+          <button mat-icon-button
+              class="add-button" 
+              aria-label="Add Cast Button"
+              (click)="addCast()">
             <mat-icon [inline]="true" class="add-button-icon">
               add
             </mat-icon>
@@ -38,7 +52,9 @@
     </div>
   </div>
   <div class="drag-and-drop-container">
-    <app-cast-drag-and-drop #castDragAndDrop (castChangeEmitter)="onEditCast($event)">
+    <app-cast-drag-and-drop
+        #castDragAndDrop
+        (castChangeEmitter)="onEditCast($event)">
     </app-cast-drag-and-drop>
   </div>
 </div>

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.scss
@@ -1,5 +1,6 @@
 @import "src/colors";
 @import "src/constants";
+@import "src/styles";
 
 .root-container {
   display: flex;

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -11,7 +11,7 @@ type PieceMenuItem = {
   name: string;
   sortString: string;
   hasSibling: boolean;
-  pieceIx: number;
+  pieceIndex: number;
 };
 
 @Component({
@@ -63,8 +63,8 @@ export class CastEditorV2 implements OnInit {
     }
   }
 
-  selectPiece(pieceIx: number) {
-    this.setPiece(this.allPieces[pieceIx]);
+  selectPiece(pieceIndex: number) {
+    this.setPiece(this.allPieces[pieceIndex]);
   }
 
   private setPiece(piece: Piece) {
@@ -103,7 +103,7 @@ export class CastEditorV2 implements OnInit {
   }
 
   private buildPopupList() {
-    this.popupPieceList = this.allPieces.map((piece, pieceIx) => {
+    this.popupPieceList = this.allPieces.map((piece, pieceIndex) => {
       const existingCasts = this.allCasts.filter((cast) => cast.segment == piece.uuid);
       const prefix = existingCasts.length === 0 ? " " : "z";
       const name = existingCasts.length === 0 ? "*" + piece.name : piece.name;
@@ -111,7 +111,7 @@ export class CastEditorV2 implements OnInit {
         name: name,
         sortString: prefix + piece.name,
         hasSibling: piece.siblingId > 0,
-        pieceIx: pieceIx,
+        pieceIndex: pieceIndex,
       };
     });
     this.popupPieceList.sort((a, b) => a.sortString < b.sortString ? -1 : 1);
@@ -121,7 +121,7 @@ export class CastEditorV2 implements OnInit {
     this.allPieces = pieces.filter(val => val.type == "PIECE");
     this.buildPopupList();
     if (!this.selectedPiece && this.allPieces.length > 0) {
-      this.selectPiece(this.popupPieceList[0].pieceIx);
+      this.selectPiece(this.popupPieceList[0].pieceIndex);
     }
     this.checkForUrlCompliance();
     this.piecesLoaded = true;

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -7,7 +7,7 @@ import { Cast, CastApi } from '../api/cast_api.service';
 import { Piece, PieceApi } from '../api/piece_api.service';
 import { CastDragAndDrop } from './cast-drag-and-drop.component';
 
-type PopupData = {
+type PieceMenuItem = {
   name: string;
   sortString: string;
   hasSibling: boolean;
@@ -27,7 +27,7 @@ export class CastEditorV2 implements OnInit {
   allCasts: Cast[] = [];
   filteredCasts: Cast[] = [];
   allPieces: Piece[] = [];
-  popupList: PopupData[] = [];
+  popupPieceList: PieceMenuItem[] = [];
   lastSelectedCastIndex: number;
   lastSelectedCast: Cast;
   dataLoaded = false;
@@ -52,22 +52,22 @@ export class CastEditorV2 implements OnInit {
     this.pieceAPI.getAllPieces();
   }
 
-  checkDataLoaded(): boolean {
+  private checkDataLoaded(): boolean {
     this.dataLoaded = this.piecesLoaded && this.castsLoaded;
     return this.dataLoaded;
   }
 
-  updateFilteredCasts() {
+  private updateFilteredCasts() {
     if (this.selectedPiece) {
       this.filteredCasts = this.allCasts.filter((val) => val.segment == this.selectedPiece.uuid);
     }
   }
 
-  onSelectPiece(pieceIx: number) {
+  selectPiece(pieceIx: number) {
     this.setPiece(this.allPieces[pieceIx]);
   }
 
-  setPiece(piece: Piece) {
+  private setPiece(piece: Piece) {
     if (this.selectedPiece && piece.uuid == this.selectedPiece.uuid) {
       return;
     }
@@ -82,7 +82,7 @@ export class CastEditorV2 implements OnInit {
     }
   }
 
-  checkForUrlCompliance() {
+  private checkForUrlCompliance() {
     if (this.selectedPiece) {
       this.updateFilteredCasts();
     }
@@ -102,9 +102,9 @@ export class CastEditorV2 implements OnInit {
     }
   }
 
-  buildPopupList() {
-    this.popupList = this.allPieces.map((piece, pieceIx) => {
-      const existingCasts = this.allCasts.filter((val) => val.segment == piece.uuid);
+  private buildPopupList() {
+    this.popupPieceList = this.allPieces.map((piece, pieceIx) => {
+      const existingCasts = this.allCasts.filter((cast) => cast.segment == piece.uuid);
       const prefix = existingCasts.length === 0 ? " " : "z";
       const name = existingCasts.length === 0 ? "*" + piece.name : piece.name;
       return {
@@ -114,21 +114,21 @@ export class CastEditorV2 implements OnInit {
         pieceIx: pieceIx,
       };
     });
-    this.popupList.sort((a, b) => a.sortString < b.sortString ? -1 : 1);
+    this.popupPieceList.sort((a, b) => a.sortString < b.sortString ? -1 : 1);
   }
 
-  onPieceLoad(pieces: Piece[]) {
+  private onPieceLoad(pieces: Piece[]) {
     this.allPieces = pieces.filter(val => val.type == "PIECE");
     this.buildPopupList();
     if (!this.selectedPiece && this.allPieces.length > 0) {
-      this.onSelectPiece(this.popupList[0].pieceIx);
+      this.selectPiece(this.popupPieceList[0].pieceIx);
     }
     this.checkForUrlCompliance();
     this.piecesLoaded = true;
     this.checkDataLoaded();
   }
 
-  onCastLoad(casts: Cast[]) {
+  private onCastLoad(casts: Cast[]) {
     if (this.castAPI.hasCast(this.urlUUID)) {
       this.dragAndDrop.selectCast(this.urlUUID);
       this.setCastURL();
@@ -171,7 +171,7 @@ export class CastEditorV2 implements OnInit {
     this.checkDataLoaded();
   }
 
-  setCastURL() {
+  private setCastURL() {
     if (this.location.path().startsWith("/cast") || this.location.path().startsWith("/cast/")) {
       this.location.replaceState("/cast/" + this.urlUUID);
     }

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -7,6 +7,13 @@ import { Cast, CastApi } from '../api/cast_api.service';
 import { Piece, PieceApi } from '../api/piece_api.service';
 import { CastDragAndDrop } from './cast-drag-and-drop.component';
 
+type PopupData = {
+  name: string;
+  sortString: string;
+  hasSibling: boolean;
+  pieceIx: number;
+};
+
 @Component({
   selector: 'app-cast-editor-v2',
   templateUrl: './cast-editor-v2.component.html',
@@ -20,6 +27,7 @@ export class CastEditorV2 implements OnInit {
   allCasts: Cast[] = [];
   filteredCasts: Cast[] = [];
   allPieces: Piece[] = [];
+  popupList: PopupData[] = [];
   lastSelectedCastIndex: number;
   lastSelectedCast: Cast;
   dataLoaded = false;
@@ -55,8 +63,8 @@ export class CastEditorV2 implements OnInit {
     }
   }
 
-  onSelectPiece(piece: Piece) {
-    this.setPiece(piece);
+  onSelectPiece(pieceIx: number) {
+    this.setPiece(this.allPieces[pieceIx]);
   }
 
   setPiece(piece: Piece) {
@@ -94,10 +102,26 @@ export class CastEditorV2 implements OnInit {
     }
   }
 
+  buildPopupList() {
+    this.popupList = this.allPieces.map((piece, pieceIx) => {
+      const existingCasts = this.allCasts.filter((val) => val.segment == piece.uuid);
+      const prefix = existingCasts.length === 0 ? " " : "z";
+      const name = existingCasts.length === 0 ? "*" + piece.name : piece.name;
+      return {
+        name: name,
+        sortString: prefix + piece.name,
+        hasSibling: piece.siblingId > 0,
+        pieceIx: pieceIx,
+      };
+    });
+    this.popupList.sort((a, b) => a.sortString < b.sortString ? -1 : 1);
+  }
+
   onPieceLoad(pieces: Piece[]) {
     this.allPieces = pieces.filter(val => val.type == "PIECE");
+    this.buildPopupList();
     if (!this.selectedPiece && this.allPieces.length > 0) {
-      this.onSelectPiece(this.allPieces[0]);
+      this.onSelectPiece(this.popupList[0].pieceIx);
     }
     this.checkForUrlCompliance();
     this.piecesLoaded = true;

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -54,7 +54,7 @@ export class PieceEditor implements OnInit {
 
   segmentTypes = ["SEGMENT", "PIECE", "REVELATION"];
   selectedSegmentType: PieceType;
-  segmentPrettyNames = ["", "Segment", "Ballet", "Revelation"]
+  segmentPrettyNames = ["", "Segment", "Ballet", "Uber Ballet"]
 
 
   constructor(private route: ActivatedRoute, private pieceAPI: PieceApi,
@@ -170,9 +170,9 @@ export class PieceEditor implements OnInit {
       originalName = "New Ballet";
       break;
     case 3:
-      name = "New Revelation";
+      name = "New Uber Ballet";
       type = "REVELATION";
-      originalName = "New Revelation";
+      originalName = "New Uber Ballet";
       break;
     }
     this.creatingPiece = true;

--- a/frontend/rolecall/src/styles.scss
+++ b/frontend/rolecall/src/styles.scss
@@ -34,6 +34,12 @@ body {
   outline: none;
 }
 
+// Standard Style Classes
+
+.std-italic-font {
+  font-style: italic;
+}
+
 /* Importing Bootstrap SCSS file. */
 @import "~bootstrap/scss/bootstrap";
 


### PR DESCRIPTION
Most of the changes to support 'Revelations' were made in the prior PR. To go 'all the way' included some fixes on the backend as well as the frontend. The largest changes on the frontend happened to the performance section. Those changes will come in a following PR.

The largest number of lines in this PR comes from 'cast-editor-v2.component.html where I 'narrowed' all lines while I made changes.

I feel most of the changes are straight forward, except possibly the ones in the first file: user_api.service.ts. We agreed that 'notifications' was less descriptive than 'canReceiveNotifications' so we changed this in the front end code. However, I didn't change it on the backend (as it would force a database wipe). As a result the backend and frontend didn't match and the data wasn't transferred, so I changed the backend interacting field back to notifications.