### PR TITLE
fixed casts loosing track of their uuid when saved

### DIFF
--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -176,7 +176,7 @@ export class CastApi {
               let uniquePositionIDs = new Set<number>();
               rawCast.subCasts.forEach(val => uniquePositionIDs.add(val.positionId));
               return {
-                uuid: this.castUUIDFromRaw(rawCast.id),
+                uuid: CastApi.castUUIDFromRaw(rawCast.id),
                 name: rawCast.name,
                 segment: String(rawCast.sectionId),
                 castCount: highestCastNumber + 1,
@@ -417,7 +417,7 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
     return undefined;
   }
 
-  castUUIDFromRaw(id: number) {
+  static castUUIDFromRaw(id: number) {
     return String(id);
   }
 }

--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -176,7 +176,7 @@ export class CastApi {
               let uniquePositionIDs = new Set<number>();
               rawCast.subCasts.forEach(val => uniquePositionIDs.add(val.positionId));
               return {
-                uuid: CastApi.castUUIDFromRaw(rawCast.id),
+                uuid: CastApi.uuidFromRaw(rawCast.id),
                 name: rawCast.name,
                 segment: String(rawCast.sectionId),
                 castCount: highestCastNumber + 1,
@@ -417,7 +417,7 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
     return undefined;
   }
 
-  static castUUIDFromRaw(id: number) {
+  static uuidFromRaw(id: number) {
     return String(id);
   }
 }

--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -64,6 +64,7 @@ export type Cast = {
   filled_positions: CastPosition[];
 }
 
+// Get all casts
 export type AllCastsResponse = {
   data: {
     casts: Cast[]
@@ -71,6 +72,7 @@ export type AllCastsResponse = {
   warnings: string[]
 };
 
+// Get one specific cast
 export type OneCastResponse = {
   data: {
     cast: Cast
@@ -176,7 +178,7 @@ export class CastApi {
               let uniquePositionIDs = new Set<number>();
               rawCast.subCasts.forEach(val => uniquePositionIDs.add(val.positionId));
               return {
-                uuid: CastApi.uuidFromRaw(rawCast.id),
+                uuid: String(rawCast.id),
                 name: rawCast.name,
                 segment: String(rawCast.sectionId),
                 castCount: highestCastNumber + 1,
@@ -213,8 +215,8 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
       observe: "response",
       withCredentials: true
     }).toPromise().catch((errorResp) => errorResp).then(
-        resp => this.respHandler.checkResponse<any>(resp)).then(async na => {
-      const rawCast = this.PatchPostPrep(cast);
+        resp => this.respHandler.checkResponse<any>(resp)).then(async notUsed => {
+      const rawCast = this.patchPostPrep(cast);
       return this.http.post(environment.backendURL + "api/cast", rawCast, {
         headers: header,
         observe: "response",
@@ -224,7 +226,7 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
     });
   } else {
     // Do post
-    const rawCast = this.PatchPostPrep(cast);
+    const rawCast = this.patchPostPrep(cast);
     let header = await this.headerUtil.generateHeader();
     return this.http.post(environment.backendURL + "api/cast", rawCast, {
       headers: header,
@@ -235,7 +237,7 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
   }
 }
 
-  private PatchPostPrep(cast: Cast): RawCast {
+  private patchPostPrep(cast: Cast): RawCast {
     let allSubCasts: RawSubCast[] = [];
     let allPositions: Position[] = [];
     Array.from(this.pieceAPI.pieces.values()).forEach(piece => {
@@ -415,9 +417,5 @@ async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
       return this.workingCasts.get(castUUID);
     }
     return undefined;
-  }
-
-  static uuidFromRaw(id: number) {
-    return String(id);
   }
 }

--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -30,11 +30,13 @@ type RawCast = {
   subCasts: RawSubCast[]
 }
 
+// Get all casts
 type AllRawCastsResponse = {
   data: RawCast[],
   warnings: string[]
 }
 
+// Get one specific cast
 type OneRawCastsResponse = {
   data: RawCast,
   warnings: string[]
@@ -64,7 +66,6 @@ export type Cast = {
   filled_positions: CastPosition[];
 }
 
-// Get all casts
 export type AllCastsResponse = {
   data: {
     casts: Cast[]
@@ -72,7 +73,6 @@ export type AllCastsResponse = {
   warnings: string[]
 };
 
-// Get one specific cast
 export type OneCastResponse = {
   data: {
     cast: Cast
@@ -201,41 +201,41 @@ export class CastApi {
     return this.mockBackend.requestOneCast(uuid);
   };
 
-/** Hits backend with create/edit cast POST request */
-async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
-  if (environment.mockBackend) {
-    return this.mockBackend.requestCastSet(cast);
-  }
-  // Check if we have record of the cast and patch if we do
-  if (this.hasCast(cast.uuid)) {
-    // Do patch
-    let header = await this.headerUtil.generateHeader();
-    return this.http.delete(environment.backendURL + 'api/cast?castid=' + cast.uuid, {
-      headers: header,
-      observe: "response",
-      withCredentials: true
-    }).toPromise().catch((errorResp) => errorResp).then(
-        resp => this.respHandler.checkResponse<any>(resp)).then(async notUsed => {
+  /** Hits backend with create/edit cast POST request */
+  async requestCastSet(cast: Cast): Promise<HttpResponse<any>> {
+    if (environment.mockBackend) {
+      return this.mockBackend.requestCastSet(cast);
+    }
+    // Check if we have record of the cast and patch if we do
+    if (this.hasCast(cast.uuid)) {
+      // Do patch
+      let header = await this.headerUtil.generateHeader();
+      return this.http.delete(environment.backendURL + 'api/cast?castid=' + cast.uuid, {
+        headers: header,
+        observe: "response",
+        withCredentials: true
+      }).toPromise().catch((errorResp) => errorResp).then(
+          resp => this.respHandler.checkResponse<any>(resp)).then(async notUsed => {
+        const rawCast = this.patchPostPrep(cast);
+        return this.http.post(environment.backendURL + "api/cast", rawCast, {
+          headers: header,
+          observe: "response",
+          withCredentials: true
+        }).toPromise().catch((errorResp) => errorResp).then(
+            resp => this.respHandler.checkResponse<any>(resp));
+      });
+    } else {
+      // Do post
       const rawCast = this.patchPostPrep(cast);
+      let header = await this.headerUtil.generateHeader();
       return this.http.post(environment.backendURL + "api/cast", rawCast, {
         headers: header,
         observe: "response",
         withCredentials: true
       }).toPromise().catch((errorResp) => errorResp).then(
           resp => this.respHandler.checkResponse<any>(resp));
-    });
-  } else {
-    // Do post
-    const rawCast = this.patchPostPrep(cast);
-    let header = await this.headerUtil.generateHeader();
-    return this.http.post(environment.backendURL + "api/cast", rawCast, {
-      headers: header,
-      observe: "response",
-      withCredentials: true
-    }).toPromise().catch((errorResp) => errorResp).then(
-        resp => this.respHandler.checkResponse<any>(resp));
+    }
   }
-}
 
   private patchPostPrep(cast: Cast): RawCast {
     let allSubCasts: RawSubCast[] = [];

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -56,7 +56,6 @@ export class CastDragAndDrop implements OnInit {
 
   usersLoaded = false;
   castsLoaded = false;
-  piecesLoaded = false;
   dataLoaded = false;
   castSelected = false;
 
@@ -83,12 +82,8 @@ export class CastDragAndDrop implements OnInit {
     this.castAPI.castEmitter.subscribe((casts) => {
       this.onCastLoad(casts);
     });
-    this.pieceAPI.pieceEmitter.subscribe((pieces) => {
-      this.onPieceLoad(pieces);
-    });
     this.castAPI.getAllCasts();
     this.userAPI.getAllUsers();
-    this.pieceAPI.getAllPieces();
   }
 
   /** Setter to set the bolded cast number. */
@@ -107,19 +102,10 @@ export class CastDragAndDrop implements OnInit {
    * rendering.
    */
   private checkAllLoaded() {
-    if (this.usersLoaded && this.castsLoaded && this.piecesLoaded) {
+    if (this.usersLoaded && this.castsLoaded) {
       this.dataLoaded = true;
     }
     return this.dataLoaded;
-  }
-
-  /** Called when pieces are loaded from the Piece API. */
-  private onPieceLoad(pieces: Piece[]) {
-    this.piecesLoaded = true;
-    if (this.checkAllLoaded()) {
-      this.setupData();
-    }
-
   }
 
   /** Called when users are loaded from the User API. */
@@ -202,8 +188,7 @@ export class CastDragAndDrop implements OnInit {
     this.castPositions = [];
     if (!this.castAPI.hasCast(this.selectedCastUUID)) {
       this.castSelected = false;
-      // TODO: After any save the system loses track the uuid of the saved cast.
-      // It would be nice to fix [YHE].
+      this.logging.logError("Couldn't find cast: " + this.selectedCastUUID);
       return;
     }
     this.cast = this.castAPI.castFromUUID(this.selectedCastUUID);
@@ -326,6 +311,8 @@ export class CastDragAndDrop implements OnInit {
       if (!result.successful) {
         alert(result.error);
       }
+      this.selectedCastUUID = this.castAPI.castUUIDFromRaw(
+          this.castAPI.lastSavedCastId);
     });
   }
 

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -311,7 +311,7 @@ export class CastDragAndDrop implements OnInit {
       if (!result.successful) {
         alert(result.error);
       }
-      this.selectedCastUUID = this.castAPI.castUUIDFromRaw(
+      this.selectedCastUUID = CastApi.castUUIDFromRaw(
           this.castAPI.lastSavedCastId);
     });
   }

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -311,7 +311,7 @@ export class CastDragAndDrop implements OnInit {
       if (!result.successful) {
         alert(result.error);
       }
-      this.selectedCastUUID = CastApi.castUUIDFromRaw(
+      this.selectedCastUUID = CastApi.uuidFromRaw(
           this.castAPI.lastSavedCastId);
     });
   }

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -311,8 +311,7 @@ export class CastDragAndDrop implements OnInit {
       if (!result.successful) {
         alert(result.error);
       }
-      this.selectedCastUUID = CastApi.uuidFromRaw(
-          this.castAPI.lastSavedCastId);
+      this.selectedCastUUID = String(this.castAPI.lastSavedCastId);
     });
   }
 


### PR DESCRIPTION
When saved casts would lose track of their uuid, a lot of unnecessary and potentially dangerous code was executed to try to recover the uuid. Sometimes the user interface would be reset in the process.

At some point in the development process the patch save logic was changed so that during save, a cast would wipe its old database components before it would write new ones. Saving itself in a new position means a new database id which is the basis for the uuid.

I added a somewhat dirty way for the cast api to communicate the new id back to the savings routine.

In the process of debugging this, I found another problem: Every time a cast was saved it was followed by a read all cast call. This call executed a get all pieces call inside itself which would trigger a separate listener in the cast editor component. The only times pieces are needed in the cast editor is during cast creation and the casts always load their own pieces. Yet the cast editor, maybe for historical reasons, has its own onPievesLoad listener function.

The problem cased by this was that when the cast loader api got its pieces, the onPiecesLoader listener in the cast editor was triggered. Unfortunately, it was triggered too early so we didn't have the new cast collection yet. It caused a deadly embrace: when I updated the saved cast with the correct post-save uuid that worked with the new cast collection returned after the save, this new uuid clashed with a comparison with the old cast collection that was triggered by the get pieces listener that was triggered by the internal get all pieces call in the cast api.

Removing the onPiecesLoaded listener fixed that deadly embrace. Given that pieces are only used when new casts are created and the casts handle their own supply of pieces, removing the onPiecesLoaded listener should not be a problem. I found no problem during my own reasonably extensive testing.