### PR TITLE
the frontend changes for the new segment navigation

### DIFF
--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -288,4 +288,8 @@ export class PieceApi {
       }
     });
   }
+
+  static uuidFromRaw(id: number) {
+    return String(id);
+  }
 }

--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -288,8 +288,4 @@ export class PieceApi {
       }
     });
   }
-
-  static uuidFromRaw(id: number) {
-    return String(id);
-  }
 }

--- a/frontend/rolecall/src/app/piece/piece_editor.component.html
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.html
@@ -10,17 +10,31 @@
             *ngFor="let item of renderingItems"
             class="app-card piece-select"
             [class.selected-piece]="item.uuid === currentSelectedPiece.uuid "
+            [style.marginLeft.rem]="item.siblingId > 0 ? 3 : .9"
             (click)="setCurrentPieceFromIndex(item.pieceIndex)">
-            <div *ngIf="item.type === 'SUPER'; else otherSegments">
-              <h2 class="piece-name piece-underline">
-                {{ item.name }}
-              </h2>
-            </div>
+          <div
+              *ngIf="item.type === 'SUPER'; else otherSegments"
+              class="super-container">
+            <h2 class="piece-name super-name">
+              {{item.name}}
+            </h2>
+              <button
+                  mat-icon-button
+                  aria-label="Toggle Super Ballet"
+                  class="super-button"
+                  (click)="toggleOpen(item.pieceIndex)">
+                <mat-icon
+                    [inline]="true"
+                    class="add-button-icon">
+                  {{item.isOpen ? 'expand_less' : "expand_more"}}
+                </mat-icon>
+              </button>
+          </div>
             <ng-template #otherSegments>
               <h2
                   class="piece-name"
                   [class.std-italic-font]="item.siblingId > 0">
-                {{ item.name }}
+                {{item.name}}
               </h2>
             </ng-template>
         </div>

--- a/frontend/rolecall/src/app/piece/piece_editor.component.scss
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.scss
@@ -52,12 +52,24 @@
   white-space: nowrap;
 }
 
-.piece-underline {
+.selected-piece {
+  background-color: $offoffWhite;
+}
+
+.super-container {
+  display: flex;
+}
+
+.super-name {
+  width: 80%;
   text-decoration: underline;
 }
 
-.selected-piece {
-  background-color: $offoffWhite;
+.super-button {
+  margin-top: .6rem;
+  border-radius: $borderRadius;
+  height: 5vh;
+  width: 5vh; 
 }
 
 .add-button-width-container-left {
@@ -65,7 +77,7 @@
   flex-direction: row;
   justify-content: flex-end;
   min-height: 7.5vh;
-  width: 96%;
+  width: 96.5%;
 }
 
 // Space below the Positions

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -113,13 +113,13 @@ export class PieceEditor implements OnInit {
             this.buildRenderingItem(displayPiece, displayieceIndex));
   }
 
-  private buildRenderingItem(displayPiece: WorkingPiece, displayieceIndex: number) {
+  private buildRenderingItem(displayPiece: WorkingPiece, displayPieceIndex: number) {
     const hasNoChidren = displayPiece.type === 'SEGMENT'
         ? false : displayPiece.positions.length === 0;
     const name = hasNoChidren ? '*' + displayPiece.name : displayPiece.name;
     return {
       name,
-      pieceIndex: displayieceIndex,
+      pieceIndex: displayPieceIndex,
       siblingId: displayPiece.siblingId,
       type: displayPiece.type,
       isOpen: displayPiece.isOpen,

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -109,8 +109,8 @@ export class PieceEditor implements OnInit {
       }
     }
     this.renderingItems = this.displayedPieces.map(
-        (displayPiece, displayieceIndex) =>
-            this.buildRenderingItem(displayPiece, displayieceIndex));
+        (displayPiece, displayPieceIndex) =>
+            this.buildRenderingItem(displayPiece, displayPieceIndex));
   }
 
   private buildRenderingItem(displayPiece: WorkingPiece, displayPieceIndex: number) {

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -26,7 +26,7 @@ type DraggablePosition = {
 type WorkingPiece = Piece & {
   addingPositions: DraggablePosition[];
   originalName: string;
-  isOpen;
+  isOpen: boolean;
 };
 
 type RenderingItem = {
@@ -101,7 +101,7 @@ export class PieceEditor implements OnInit {
             (a, b) => a.order < b.order ? -1 : 1);
         let children: WorkingPiece[] = [];
         for (const position of this.displayedPieces[i].positions) {
-          const uuid = PieceApi.uuidFromRaw(position.siblingId);
+          const uuid = String(position.siblingId);
           const child = this.workingPieces.find(wp => wp.uuid === uuid);
           children.push(child);
         }
@@ -109,19 +109,22 @@ export class PieceEditor implements OnInit {
       }
     }
     this.renderingItems = this.displayedPieces.map(
-        (displayPiece, displayieceIndex) => {
-      const hasNoChidren = displayPiece.type === 'SEGMENT'
-          ? false : displayPiece.positions.length === 0;
-      const name = hasNoChidren ? '*' + displayPiece.name : displayPiece.name;
-      return {
-        name,
-        pieceIndex: displayieceIndex,
-        siblingId: displayPiece.siblingId,
-        type: displayPiece.type,
-        isOpen: displayPiece.isOpen,
-        uuid: displayPiece.uuid,
-      };
-    });
+        (displayPiece, displayieceIndex) =>
+            this.buildRenderingItem(displayPiece, displayieceIndex));
+  }
+
+  private buildRenderingItem(displayPiece: WorkingPiece, displayieceIndex: number) {
+    const hasNoChidren = displayPiece.type === 'SEGMENT'
+        ? false : displayPiece.positions.length === 0;
+    const name = hasNoChidren ? '*' + displayPiece.name : displayPiece.name;
+    return {
+      name,
+      pieceIndex: displayieceIndex,
+      siblingId: displayPiece.siblingId,
+      type: displayPiece.type,
+      isOpen: displayPiece.isOpen,
+      uuid: displayPiece.uuid,
+    };
   }
 
   onPieceLoad(pieces: Piece[]) {
@@ -550,7 +553,6 @@ export class PieceEditor implements OnInit {
     const superBallet = this.displayedPieces[index];
     if (superBallet.type == 'SUPER') {
       superBallet.isOpen = !superBallet.isOpen;
-      this.pieceAPI.setPiece(superBallet);
     }
     this.buildRenderingList();
   }


### PR DESCRIPTION
The customer was confused by our current segment navigation. Basically, once we added support for revelations like super ballets, where there exists a hierarchy between super ballets and the ballets that belong to them, a linear interface is inadequate, in spite of the tweaks we added to identify the different types of pieces/segments.

The customer asked for a folder like structure where super ballets can be open, and expose their ballets, or closed, and hide them. This requires a database change, and that is why I am rushing this change.