### PR TITLE
possible fix for customer error

### DIFF
--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.html
@@ -32,7 +32,7 @@
       </div>
       <div class="cast-select-container">
         <div
-            *ngFor="let cast of filteredCasts"
+            *ngFor="let cast of selectedPieceCasts"
             class="app-card cast-select"
             [class.selected-cast]="cast.uuid == castDragAndDrop.selectedCastUUID"
             (click)="setCurrentCast({cast: cast})">

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -203,10 +203,10 @@ export class CastEditorV2 implements OnInit {
       index = this.selectedPieceCasts.findIndex(
           findCast => cast.uuid === findCast.uuid);
     }
-    if (index === undefined || index === -1) {
-      this.lastSelectedCastIndex = undefined;
-    } else {
+    if (index >= 0) {
       this.lastSelectedCastIndex = index;
+    } else {
+      this.lastSelectedCastIndex = undefined;
     }
     this.lastSelectedCast = cast ? cast : this.lastSelectedCast;
     this.selectedCast = cast;

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -25,7 +25,7 @@ export class CastEditorV2 implements OnInit {
   selectedPiece: Piece;
   urlUUID: APITypes.CastUUID;
   allCasts: Cast[] = [];
-  filteredCasts: Cast[] = [];
+  selectedPieceCasts: Cast[] = [];
   allPieces: Piece[] = [];
   popupPieceList: PieceMenuItem[] = [];
   lastSelectedCastIndex: number;
@@ -63,7 +63,7 @@ export class CastEditorV2 implements OnInit {
 
   private updateFilteredCasts() {
     if (this.selectedPiece) {
-      this.filteredCasts = this.allCasts.filter(
+      this.selectedPieceCasts = this.allCasts.filter(
           cast => cast.segment === this.selectedPiece.uuid);
     }
   }
@@ -83,7 +83,7 @@ export class CastEditorV2 implements OnInit {
     this.selectedPiece = piece;
     this.updateFilteredCasts();
     if (autoSelectFirst) {
-      this.setCurrentCast({cast: this.filteredCasts[0]});
+      this.setCurrentCast({cast: this.selectedPieceCasts[0]});
     }
   }
 
@@ -101,10 +101,10 @@ export class CastEditorV2 implements OnInit {
         this.setPiece(foundPiece);
       }
     }
-    if (this.selectedPiece && !this.filteredCasts.find(
+    if (this.selectedPiece && !this.selectedPieceCasts.find(
           cast => cast.uuid === this.urlUUID)) {
-      if (this.filteredCasts.length > 0) {
-        this.setCurrentCast({cast: this.filteredCasts[0]});
+      if (this.selectedPieceCasts.length > 0) {
+        this.setCurrentCast({cast: this.selectedPieceCasts[0]});
       }
     }
   }
@@ -157,8 +157,8 @@ export class CastEditorV2 implements OnInit {
           this.lastSelectedCast = foundCast;
           this.selectedCast = foundCast;
         } else {
-          if (this.filteredCasts.length > 0) {
-            this.selectedCast = this.filteredCasts[
+          if (this.selectedPieceCasts.length > 0) {
+            this.selectedCast = this.selectedPieceCasts[
                 this.lastSelectedCastIndex
                 ? this.lastSelectedCastIndex - 1
                 : 0];
@@ -167,8 +167,8 @@ export class CastEditorV2 implements OnInit {
           }
         }
       } else {
-        if (this.filteredCasts.length > 0) {
-          this.selectedCast = this.filteredCasts[
+        if (this.selectedPieceCasts.length > 0) {
+          this.selectedCast = this.selectedPieceCasts[
               this.lastSelectedCastIndex ? this.lastSelectedCastIndex - 1 : 0];
         } else {
           this.selectedCast = casts[0];
@@ -197,12 +197,13 @@ export class CastEditorV2 implements OnInit {
 
   setCurrentCast({cast, index}: {
     cast: Cast | undefined,
-    index?: number | undefined,
+    index?: number,
   }) {
-    if (!index && cast) {
-      index = this.filteredCasts.findIndex((cast) => cast.uuid === cast.uuid);
+    if (index === undefined && cast) {
+      index = this.selectedPieceCasts.findIndex(
+          findCast => cast.uuid === findCast.uuid);
     }
-    if (!index || index === -1) {
+    if (index === undefined || index === -1) {
       this.lastSelectedCastIndex = undefined;
     } else {
       this.lastSelectedCastIndex = index;
@@ -230,8 +231,9 @@ export class CastEditorV2 implements OnInit {
         };
       })
     };
-    await this.setCurrentCast({cast: newCast});
+    this.selectedPieceCasts.push(newCast);
     await this.castAPI.setCast(newCast, true);
+    this.setCurrentCast({cast: newCast});
     await this.castAPI.getAllCasts();
   }
 }


### PR DESCRIPTION
I found an instance where the system lost track of a newly created cast.

The fix involves
1) some renaming so it was clearer what was stored in an array,
2) fixing of some errors introduced by me earlier when we removed the deprecated null-and-undefined check,
3) reordering of some improperly ordered statements when a new cast is created.

I hope this fix will fix the customer error we discovered today.
