### PR TITLE
Fix service tests

### DIFF
--- a/frontend/rolecall/angular.json
+++ b/frontend/rolecall/angular.json
@@ -100,8 +100,14 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",
-              "src/styles.scss"
+              "src/styles/std.scss",
+              "src/styles/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles"
+              ]
+            },
             "scripts": []
           }
         },

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
@@ -1,5 +1,5 @@
 @import "../../styles/colors";
-@import "constants";
+@import "../../styles/constants";
 
 $cellHeight: 3.5rem;
 $cellWidth: 14rem;
@@ -49,6 +49,7 @@ $lastCellFillerWidth: 2.2rem;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: $cellWidth;
+
   &ColHeader {
     padding-top: 1.25rem;
     color: $gray;
@@ -56,6 +57,7 @@ $lastCellFillerWidth: 2.2rem;
     font-weight: bold;
     vertical-align: middle;
   }
+
   &RowHeader {
     padding-top: 1.25rem;
     padding-left: 2rem;
@@ -64,6 +66,7 @@ $lastCellFillerWidth: 2.2rem;
     font-weight: bold;
     vertical-align: middle;
   }
+
   &BothHeader {
     padding: 0;
     padding-left: 1rem;
@@ -88,6 +91,7 @@ $lastCellFillerWidth: 2.2rem;
   padding-top: 0.25rem;
   position: relative;
   max-width: 90%;
+
   &:focus {
     border: none;
   }
@@ -124,6 +128,7 @@ $lastCellFillerWidth: 2.2rem;
   margin-bottom: .7rem;
   width: 4vh;
 }
+
 .export-button-icon {
   font-size: 2.5rem;
   vertical-align: middle;
@@ -239,7 +244,7 @@ $lastCellFillerWidth: 2.2rem;
   }
 }
 
-  
+
 .button-v-wrapper {
   background: $offWhite;
   width: $bothFillerWidth;
@@ -254,7 +259,7 @@ $lastCellFillerWidth: 2.2rem;
   .mat-button-base {
     height: 1rem;
   }
- 
+
   .button-v-container {
     display: flex;
     flex-direction: column;
@@ -266,7 +271,7 @@ $lastCellFillerWidth: 2.2rem;
       width: 1rem;
 
       .count-icon1 {
-        margin-top : -.2rem;
+        margin-top: -.2rem;
       }
     }
 
@@ -274,7 +279,7 @@ $lastCellFillerWidth: 2.2rem;
       height: 1rem;
 
       .count-icon2 {
-        margin-top : -.2rem;
+        margin-top: -.2rem;
       }
     }
   }

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.scss
@@ -194,7 +194,6 @@ $lastCellFillerWidth: 2.2rem;
   width: 16.6666%;
 }
 
-
 .cdk-drag-placeholder {
   opacity: 0.4;
 }
@@ -243,7 +242,6 @@ $lastCellFillerWidth: 2.2rem;
     }
   }
 }
-
 
 .button-v-wrapper {
   background: $offWhite;

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.scss
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.scss
@@ -1,5 +1,5 @@
 @import "../../styles/colors";
-@import "constants";
+@import "../../styles/constants";
 
 .root-container {
   display: flex;

--- a/frontend/rolecall/src/app/performance/performance-editor.component.scss
+++ b/frontend/rolecall/src/app/performance/performance-editor.component.scss
@@ -1,5 +1,5 @@
 @import "../../styles/colors";
-@import "constants";
+@import "../../styles/constants";
 
 $buttonRowHeight: 5rem;
 
@@ -60,6 +60,7 @@ $buttonRowHeight: 5rem;
             margin: 1em;
             width: 6vh;
           }
+
           .dup-button-icon {
             font-size: 2.5em;
             vertical-align: middle;
@@ -125,6 +126,7 @@ $buttonRowHeight: 5rem;
             margin: 1em;
             width: 6vh;
           }
+
           .dup-button-icon {
             font-size: 2.5em;
             vertical-align: middle;
@@ -208,6 +210,7 @@ $buttonRowHeight: 5rem;
               margin: 1em;
               width: 6vh;
             }
+
             .reset-button-icon {
               font-size: 2.5em;
               vertical-align: middle;
@@ -225,6 +228,7 @@ $buttonRowHeight: 5rem;
             max-width: 90%;
             padding-left: 1rem;
             width: auto;
+
             &:focus {
               border: none;
             }
@@ -295,6 +299,7 @@ $buttonRowHeight: 5rem;
               resize: none;
               white-space: normal;
               width: 100%;
+
               &:focus {
                 border: none;
               }
@@ -381,9 +386,11 @@ $buttonRowHeight: 5rem;
               padding-top: 0.75em;
               position: relative;
               resize: none;
+
               &:focus {
                 border: none;
               }
+
               white-space: normal;
               width: 100%;
             }
@@ -450,6 +457,7 @@ $buttonRowHeight: 5rem;
     }
   }
 }
+
 .piece-container {
   display: flex;
   flex-direction: row;
@@ -472,6 +480,7 @@ $buttonRowHeight: 5rem;
       padding-left: 1em;
       padding-right: 1em;
       width: 100%;
+
       .delete-button-icon {
         font-size: 6vh;
         vertical-align: middle;
@@ -479,6 +488,7 @@ $buttonRowHeight: 5rem;
     }
   }
 }
+
 .piece-name-card {
   margin-left: 1em;
   width: calc(100% - 2em);
@@ -489,6 +499,7 @@ $buttonRowHeight: 5rem;
     margin-left: 1em;
     padding-bottom: 0.5em;
     padding-top: 0.5em;
+
     &-delete {
       font-size: x-large;
       font-weight: bold;
@@ -499,9 +510,11 @@ $buttonRowHeight: 5rem;
     }
   }
 }
+
 #piece-list {
   overflow-y: scroll;
 }
+
 #program-list {
   height: 100%;
   overflow-y: scroll;
@@ -537,6 +550,7 @@ $buttonRowHeight: 5rem;
           margin: 1em;
           width: 6vh;
         }
+
         .dup-button-icon {
           font-size: 2.5em;
           vertical-align: middle;
@@ -582,6 +596,7 @@ $buttonRowHeight: 5rem;
   .right-card-container {
     height: calc(90vh - 5rem);
     width: 75vw;
+
     .right-card {
       background: $offWhite;
       height: calc(100% - 1rem);
@@ -597,6 +612,7 @@ $buttonRowHeight: 5rem;
           display: flex;
           flex-direction: row;
           justify-content: space-between;
+
           &-solo {
             height: 100%;
             justify-content: center;
@@ -605,11 +621,13 @@ $buttonRowHeight: 5rem;
           .tool {
             height: 2.5rem;
             width: 32%;
+
             &-solo {
               width: 100%;
             }
           }
         }
+
         .cast-drag-and-drop-container {
           height: calc(100% - 5rem);
         }
@@ -671,6 +689,7 @@ $buttonRowHeight: 5rem;
             margin-top: 0.5rem;
             width: 6vh;
           }
+
           .export-button-icon {
             font-size: 2.5rem;
             vertical-align: middle;
@@ -744,9 +763,11 @@ $buttonRowHeight: 5rem;
 .cdk-drag-animating {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
+
 .cdk-drag-placeholder {
   opacity: 0;
 }
+
 .cdk-drop-list-dragging :not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/frontend/rolecall/src/app/piece/piece_editor.component.scss
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.scss
@@ -1,5 +1,5 @@
 @import "../../styles/colors";
-@import "constants";
+@import "../../styles/constants";
 
 // Overall container for panels styling
 .panel-container {
@@ -67,7 +67,7 @@
   margin-top: .6rem;
   border-radius: $borderRadius;
   height: 5vh;
-  width: 5vh; 
+  width: 5vh;
 }
 
 .add-button-width-container-left {
@@ -163,6 +163,7 @@
   flex-direction: row;
   justify-content: space-between;
   height: min-content;
+
   &-no-positions {
     height: 100%;
   }
@@ -197,6 +198,7 @@
   padding-left: 1em;
   padding-right: 1em;
   padding-top: 0.5em;
+
   &:hover {
     background: red;
     color: $white;
@@ -247,6 +249,7 @@
   padding-left: 0.5em;
   padding-top: 0.25em;
   position: relative;
+
   &:focus {
     border: none;
   }
@@ -265,6 +268,7 @@
   padding-left: 0.5em;
   padding-top: 0.25em;
   position: relative;
+
   &:focus {
     border: none;
   }

--- a/frontend/rolecall/src/app/services/error-dialog.html
+++ b/frontend/rolecall/src/app/services/error-dialog.html
@@ -1,13 +1,27 @@
-<h1 mat-dialog-title class="title">Error</h1>
+<h1 class="title" mat-dialog-title>
+  Error
+</h1>
 <div mat-dialog-content>
   <br>
-  <p class="subheader" style="font-weight: normal;">{{ data.errorEvent.url }}</p>
+  <p class="subheader" style="font-weight: normal;">
+    {{data.errorEvent.url}}
+  </p>
   <br>
-  <p class="subheader">{{ "Status " + data.errorEvent.status + ": " + data.errorEvent.statusText }} </p>
-  <p class="content">{{ data.errorEvent.errorMessage }}</p>
+  <p class="subheader">
+    {{"Status " + data.errorEvent.status + ": " + data.errorEvent.statusText}}
+  </p>
+  <p class="content">
+    {{data.errorEvent.errorMessage}}
+  </p>
   <br>
   <br>
 </div>
-<div mat-dialog-actions class="button-bar">
-  <button mat-raised-button class="ok-button" (click)="onOkClick('OK')" cdkFocusInitial>OK</button>
+<div class="button-bar" mat-dialog-actions>
+  <button
+      class="ok-button"
+      mat-raised-button
+      cdkFocusInitial
+      (click)="onOkClick('OK')">
+    OK
+  </button>
 </div>

--- a/frontend/rolecall/src/app/services/error-dialog.scss
+++ b/frontend/rolecall/src/app/services/error-dialog.scss
@@ -4,10 +4,7 @@
   border-radius: 0.25em;
   font-size: x-large;
   font-weight: 800;
-  padding-bottom: 0.5em;
-  padding-left: 1em;
-  padding-right: 1em;
-  padding-top: 0.5em;
+  padding: 0.5em 1em;
   width: fit-content;
 }
 

--- a/frontend/rolecall/src/app/services/header-utility.service.spec.ts
+++ b/frontend/rolecall/src/app/services/header-utility.service.spec.ts
@@ -1,13 +1,13 @@
-import { TestBed } from '@angular/core/testing';
+import {LoginApi} from '../api/login_api.service';
 
-import { HeaderUtilityService } from './header-utility.service';
+import {HeaderUtilityService} from './header-utility.service';
 
 describe('HeaderUtilityService', () => {
   let service: HeaderUtilityService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(HeaderUtilityService);
+    const fakeLoginService = {} as LoginApi;
+    service = new HeaderUtilityService(fakeLoginService);
   });
 
   it('should be created', () => {

--- a/frontend/rolecall/src/app/services/header-utility.service.ts
+++ b/frontend/rolecall/src/app/services/header-utility.service.ts
@@ -1,40 +1,42 @@
-import { HttpHeaders } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { environment } from 'src/environments/environment';
-import { LoginApi } from '../api/login_api.service';
+import {HttpHeaders} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {environment} from 'src/environments/environment';
 
-@Injectable({
-  providedIn: 'root'
-})
+import {LoginApi} from '../api/login_api.service';
+
+@Injectable({providedIn: 'root'})
 export class HeaderUtilityService {
+  private sentToken = false;
 
-  constructor(private loginAPI: LoginApi) { }
-
-  sentToken = false;
-
-  updateSentToken() {
-    this.sentToken = this.loginAPI.isLoggedIn && this.sentToken;
+  constructor(private loginAPI: LoginApi) {
   }
 
   generateHeader(): Promise<HttpHeaders> {
     this.updateSentToken();
+
     return this.loginAPI.loginPromise.then(() => {
       if (this.sentToken) {
-        let headers = new HttpHeaders({
+        const headers = new HttpHeaders({
           'Content-Type': 'application/json; charset=utf-8',
-          'EMAIL': environment.useDevEmail ? environment.devEmail : this.loginAPI.email,
+          'EMAIL': environment.useDevEmail ? environment.devEmail :
+              this.loginAPI.email,
         });
         return headers;
       } else {
-        let headers = new HttpHeaders({
+        const headers = new HttpHeaders({
           'Content-Type': 'application/json; charset=utf-8',
-          'EMAIL': environment.useDevEmail ? environment.devEmail : this.loginAPI.email,
-          'AUTHORIZATION': 'Bearer ' + this.loginAPI.user.getAuthResponse().id_token
+          'EMAIL': environment.useDevEmail ? environment.devEmail :
+              this.loginAPI.email,
+          'AUTHORIZATION': 'Bearer '
+                           + this.loginAPI.user.getAuthResponse().id_token
         });
         this.sentToken = true;
         return headers;
       }
-    })
+    });
   }
 
+  private updateSentToken() {
+    this.sentToken = this.loginAPI.isLoggedIn && this.sentToken;
+  }
 }

--- a/frontend/rolecall/src/app/services/logging.service.spec.ts
+++ b/frontend/rolecall/src/app/services/logging.service.spec.ts
@@ -1,37 +1,35 @@
-import { TestBed } from '@angular/core/testing';
-import { ERROR_PREFIX, INFO_PREFIX, LoggingService, LOG_PREFIX, WARN_PREFIX } from './logging.service';
-
+import {ERROR_PREFIX, LOG_PREFIX, LoggingService, WARN_PREFIX} from './logging.service';
 
 describe('LoggingService', () => {
+  const testMessage = 'TEST_MSG';
   let service: LoggingService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(LoggingService);
+    service = new LoggingService();
+  });
+
+  it('can log info', () => {
     spyOn(window.console, 'log');
-  });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
-
-  it('should call console log for each log type', () => {
-    let testMessage = "TEST_MSG";
     service.log(testMessage);
 
-    expect(window.console.log).toHaveBeenCalledWith(LOG_PREFIX + testMessage);
+    expect(window.console.log).toHaveBeenCalledWith(LOG_PREFIX, testMessage);
+  });
 
-    service.logInfo(testMessage);
-
-    expect(window.console.log).toHaveBeenCalledWith(INFO_PREFIX + testMessage);
+  it('can log warning', () => {
+    spyOn(window.console, 'warn');
 
     service.logWarn(testMessage);
 
-    expect(window.console.log).toHaveBeenCalledWith(WARN_PREFIX + testMessage);
+    expect(window.console.warn).toHaveBeenCalledWith(WARN_PREFIX, testMessage);
+  });
+
+  it('can log error', () => {
+    spyOn(window.console, 'error');
 
     service.logError(testMessage);
 
-    expect(window.console.log).toHaveBeenCalledWith(ERROR_PREFIX + testMessage);
+    expect(window.console.error)
+        .toHaveBeenCalledWith(ERROR_PREFIX, testMessage);
   });
-
 });

--- a/frontend/rolecall/src/app/services/logging.service.ts
+++ b/frontend/rolecall/src/app/services/logging.service.ts
@@ -1,31 +1,25 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 
-/** Logging prefixes */
-export const ERROR_PREFIX = "{{ ERROR }} :: ";
-export const WARN_PREFIX = "{{ WARN }} :: ";
-export const INFO_PREFIX = "{{ INFO }} :: ";
-export const LOG_PREFIX = "{{ LOG }} :: ";
+/** Logging prefixes. */
+export const ERROR_PREFIX = '{{ ERROR }} :: ';
+export const WARN_PREFIX = '{{ WARN }} :: ';
+export const LOG_PREFIX = '{{ LOG }} :: ';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable({providedIn: 'root'})
 export class LoggingService {
 
-  /** Logs an error */
+  /** Logs an error. */
   public logError(err: any) {
-    console.log(ERROR_PREFIX + JSON.stringify(err));
-  }
-  /** Logs a warning */
-  public logWarn(warn: any) {
-    console.log(WARN_PREFIX + warn);
-  }
-  /** Logs information */
-  public logInfo(info: any) {
-    console.log(INFO_PREFIX + info);
-  }
-  /** Logs a general log */
-  public log(log: any) {
-    console.log(LOG_PREFIX + log);
+    console.error(ERROR_PREFIX, err);
   }
 
+  /** Logs a warning. */
+  public logWarn(warn: any) {
+    console.warn(WARN_PREFIX, warn);
+  }
+
+  /** Logs a general log. */
+  public log(log: any) {
+    console.log(LOG_PREFIX, log);
+  }
 }

--- a/frontend/rolecall/src/app/services/request-interceptor.service.spec.ts
+++ b/frontend/rolecall/src/app/services/request-interceptor.service.spec.ts
@@ -1,13 +1,12 @@
-import { TestBed } from '@angular/core/testing';
-
-import { RequestInterceptorService } from './request-interceptor.service';
+import {RequestInterceptorService} from './request-interceptor.service';
+import {LoginApi} from '../api/login_api.service';
 
 describe('RequestInterceptorService', () => {
   let service: RequestInterceptorService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(RequestInterceptorService);
+    const fakeLoginApi = {} as LoginApi;
+    service = new RequestInterceptorService(fakeLoginApi);
   });
 
   it('should be created', () => {

--- a/frontend/rolecall/src/app/services/request-interceptor.service.ts
+++ b/frontend/rolecall/src/app/services/request-interceptor.service.ts
@@ -1,17 +1,18 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { environment } from 'src/environments/environment';
-import { LoginApi } from '../api/login_api.service';
+import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
+import {environment} from 'src/environments/environment';
 
-@Injectable({
-  providedIn: 'root'
-})
+import {LoginApi} from '../api/login_api.service';
+
+@Injectable({providedIn: 'root'})
 export class RequestInterceptorService implements HttpInterceptor {
+  constructor(private loginAPI: LoginApi) {
+  }
 
-  constructor(private loginAPI: LoginApi) { }
-
-  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(
+      req: HttpRequest<any>,
+      next: HttpHandler): Observable<HttpEvent<any>> {
     // Ensures fresh Google OAuth token
     this.loginAPI.login(false);
     if (environment.logRequests) {

--- a/frontend/rolecall/src/app/services/response-status-handler.service.spec.ts
+++ b/frontend/rolecall/src/app/services/response-status-handler.service.spec.ts
@@ -1,13 +1,16 @@
-import { TestBed } from '@angular/core/testing';
+import {MatDialog} from '@angular/material/dialog';
 
-import { ResponseStatusHandlerService } from './response-status-handler.service';
+import {LoginApi} from '../api/login_api.service';
+
+import {ResponseStatusHandlerService} from './response-status-handler.service';
 
 describe('ResponseStatusHandlerService', () => {
   let service: ResponseStatusHandlerService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ResponseStatusHandlerService);
+    const fakeLoginApi = {} as LoginApi;
+    const fakeMatDialog = {} as MatDialog;
+    service = new ResponseStatusHandlerService(fakeMatDialog, fakeLoginApi);
   });
 
   it('should be created', () => {

--- a/frontend/rolecall/src/app/user/user-editor.component.scss
+++ b/frontend/rolecall/src/app/user/user-editor.component.scss
@@ -1,5 +1,5 @@
 @import "../../styles/colors";
-@import "constants";
+@import "../../styles/constants";
 
 // Overall container for panels styling
 .panel-container {

--- a/frontend/rolecall/tslint.json
+++ b/frontend/rolecall/tslint.json
@@ -74,7 +74,7 @@
     "no-var-requires": false,
     "object-literal-key-quotes": [
       true,
-      "as-needed"
+      "consistent"
     ],
     "quotemark": [
       true,


### PR DESCRIPTION
Service cleanup and test fixes:

- Fixed style import error when running `ng test`
- Fixed several service tests to pass
- Cleaned up basic style
- Removed one redundant "logging" function that was not used
- Switched 'warn' and 'error' logging functions to log with the appropriate level instead of just 'info', and to properly print out any passed in objects