### PR TITLE
A fix I forgot

### DIFF
--- a/frontend/rolecall/src/app/performance/performance-editor.component.ts
+++ b/frontend/rolecall/src/app/performance/performance-editor.component.ts
@@ -156,7 +156,7 @@ export class PerformanceEditor implements OnInit, OnDestroy, AfterViewChecked {
     // Clear a key parameter to prevent deadly embrace
     if (this.castDnD) {
       this.castDnD.castSelected = false;
-  }
+    }
 
     this.performanceAPI.setPerformance(this.dataToPerformance());
     this.deleteWorkingCasts();

--- a/frontend/rolecall/src/app/performance/performance-editor.component.ts
+++ b/frontend/rolecall/src/app/performance/performance-editor.component.ts
@@ -154,7 +154,9 @@ export class PerformanceEditor implements OnInit, OnDestroy, AfterViewChecked {
     this.state.status = PerformanceStatus.DRAFT;
     // Saving casts results in an immediate cast load.
     // Clear a key parameter to prevent deadly embrace
-    this.castDnD.castSelected = false;
+    if (this.castDnD) {
+      this.castDnD.castSelected = false;
+  }
 
     this.performanceAPI.setPerformance(this.dataToPerformance());
     this.deleteWorkingCasts();

--- a/frontend/rolecall/src/app/performance/performance-editor.component.ts
+++ b/frontend/rolecall/src/app/performance/performance-editor.component.ts
@@ -440,7 +440,7 @@ export class PerformanceEditor implements OnInit, OnDestroy, AfterViewChecked {
 
   selectedSegment: Piece;
   selectedIndex: number;
-  @ViewChild('castDnD') castDnD: CastDragAndDrop;
+  @ViewChild('castDnD') castDnD?: CastDragAndDrop;
   // segment uuid to cast, primary cast, and length
   segmentToCast: Map<string, [Cast, number, number]> = new Map();
   // segment uuid to performance section ID


### PR DESCRIPTION
Sorry for being disorganized. I forgot to include this fix in the last pr.

Even though this touches a controversial section, it is bracketing a statement that is already there. The problem is that this.castDnD us sometimes undefined and causes a crash. (This happens every time the user wants to edit casts in a performance).

If you hate this code, I am OK with just removing it altogether, even though setting castSelected to false prevents the cast-system from trying to select a cast that will be renamed by the save in the next statement.