### PR TITLE
PIECES to BALLETS and PIECE to BALLET

### DIFF
--- a/backend/src/main/java/com/google/rolecall/Constants.java
+++ b/backend/src/main/java/com/google/rolecall/Constants.java
@@ -45,11 +45,11 @@ public class Constants {
     public static final String NOTIFICATIONS = "NOTIFICATIONS";
     public static final String MANAGE_PERFORMANCES = "MANAGE_PERFORMANCES";
     public static final String MANAGE_CASTS = "MANAGE_CASTS";
-    public static final String MANAGE_PIECES = "MANAGE_PIECES";
+    public static final String MANAGE_BALLETS = "MANAGE_BALLETS";
     public static final String MANAGE_ROLES = "MANAGE_ROLES";
     public static final String MANAGE_RULES = "MANAGE_RULES";
     public static final String[] PERMISSIONS = new String[] {
-        LOGIN, NOTIFICATIONS, MANAGE_PERFORMANCES, MANAGE_CASTS, MANAGE_PIECES,
+        LOGIN, NOTIFICATIONS, MANAGE_PERFORMANCES, MANAGE_CASTS, MANAGE_BALLETS,
         MANAGE_ROLES, MANAGE_RULES,
     };
   }

--- a/backend/src/main/java/com/google/rolecall/models/Section.java
+++ b/backend/src/main/java/com/google/rolecall/models/Section.java
@@ -27,7 +27,7 @@ import javax.persistence.Table;
 public class Section {
 
   public enum Type {
-    PIECE,
+    BALLET,
     SEGMENT,
     SUPER,
   }

--- a/backend/src/main/java/com/google/rolecall/models/User.java
+++ b/backend/src/main/java/com/google/rolecall/models/User.java
@@ -225,7 +225,7 @@ public class User {
     permissionsIn.add(recievesNotifications()); // NOTIFICATIONS
     permissionsIn.add(isAdmin() || canManagePerformances()); // MANGAGE_PERFORMANCES
     permissionsIn.add(isAdmin() || canManageCasts()); // MANAGE_CASTS
-    permissionsIn.add(isAdmin() || canManagePieces()); // MANAGE_PIECES
+    permissionsIn.add(isAdmin() || canManagePieces()); // MANAGE_BALLETS
     permissionsIn.add(isAdmin() || canManageRoles()); // MANAGE_ROLES
     permissionsIn.add(isAdmin() || canManageRules()); // MANAGE_RULES
 

--- a/backend/src/main/java/com/google/rolecall/restcontrollers/SectionManagement.java
+++ b/backend/src/main/java/com/google/rolecall/restcontrollers/SectionManagement.java
@@ -81,7 +81,7 @@ public class SectionManagement extends AsyncRestEndpoint {
       @RequestBody SectionInfo newSection) {
     User currentUser = getUser(principal);
     if(!currentUser.isAdmin() && !currentUser.canManagePieces()) {
-      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_PIECES));
+      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_BALLETS));
     }
 
     Section section;
@@ -110,7 +110,7 @@ public class SectionManagement extends AsyncRestEndpoint {
       @RequestBody SectionInfo newSection) {
     User currentUser = getUser(principal);
     if(!currentUser.isAdmin() && !currentUser.canManagePieces()) {
-      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_PIECES));
+      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_BALLETS));
     }
 
     Section section;
@@ -139,7 +139,7 @@ public class SectionManagement extends AsyncRestEndpoint {
       @RequestParam(value=Constants.RequestParameters.SECTION_ID, required=true) int id) {
     User currentUser = getUser(principal);
     if(!currentUser.isAdmin() && !currentUser.canManagePieces()) {
-      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_PIECES));
+      return CompletableFuture.failedFuture(insufficientPrivileges(Constants.Permissions.MANAGE_BALLETS));
     }
 
     try {

--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -104,7 +104,7 @@ public class SectionServices {
               .setNotes("")
               .setLength(0)
               .setSiblingId(0)
-              .setType(Section.Type.PIECE)
+              .setType(Section.Type.BALLET)
               .build();
           savedSubSection = sectionRepo.save(subSection);
           siblingIndexArray[loopCounter] = savedSubSection.getId();
@@ -240,7 +240,7 @@ public class SectionServices {
                 .setNotes("")
                 .setLength(0)
                 .setSiblingId(0)
-                .setType(Section.Type.PIECE)
+                .setType(Section.Type.BALLET)
                 .build();
             savedSubSection = sectionRepo.save(subSection);
             siblingIndexArray[loopCounter] = savedSubSection.getId();
@@ -317,7 +317,7 @@ public class SectionServices {
               .setNotes("")
               .setLength(0)
               .setSiblingId(pos.getId())
-              .setType(Section.Type.PIECE)
+              .setType(Section.Type.BALLET)
               .build();
           sectionRepo.save(subSection);
         }

--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -41,7 +41,7 @@ export type Position = {
   size: number,
 };
 
-export type PieceType = "SEGMENT" | "PIECE" | "SUPER";
+export type PieceType = "SEGMENT" | "BALLET" | "SUPER";
 
 export type Piece = {
   uuid: string;
@@ -143,7 +143,7 @@ export class PieceApi {
         name: piece.name,
         id: Number(piece.uuid),
         siblingId: piece.siblingId,
-        type: piece.type ? piece.type : "PIECE",
+        type: piece.type ? piece.type : "BALLET",
         positions: piece.positions.map((val, ind) => {
           return {
             ...val,
@@ -169,7 +169,7 @@ export class PieceApi {
       return this.http.post(environment.backendURL + 'api/section', {
         name: piece.name,
         siblingId: piece.siblingId,
-        type: piece.type ? piece.type : "PIECE",
+        type: piece.type ? piece.type : "BALLET",
         positions: piece.positions
       }, {
         headers: header,

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -126,7 +126,7 @@ export class CastEditorV2 implements OnInit {
   }
 
   private onPieceLoad(pieces: Piece[]) {
-    this.allPieces = pieces.filter(piece => piece.type === 'PIECE');
+    this.allPieces = pieces.filter(piece => piece.type === 'BALLET');
     this.buildPopupList();
     if (!this.selectedPiece && this.allPieces.length > 0) {
       this.selectPiece(this.popupPieceList[0].pieceIndex);

--- a/frontend/rolecall/src/app/piece/piece_editor.component.html
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.html
@@ -96,7 +96,7 @@
       </div>
 
       <div
-          *ngIf="currentSelectedPiece && (currentSelectedPiece.type == 'PIECE' || currentSelectedPiece.type == 'SUPER')"
+          *ngIf="currentSelectedPiece && (currentSelectedPiece.type == 'BALLET' || currentSelectedPiece.type == 'SUPER')"
           class="app-card positions-card">
         <div
             cdkDropList
@@ -149,7 +149,7 @@
                     class="adding-position-container">
                   <div
                       class="adding-position-name-container"
-                      [style.width.%]="currentSelectedPiece.type === 'PIECE' ? 70 : 100">
+                      [style.width.%]="currentSelectedPiece.type === 'BALLET' ? 70 : 100">
                     <app-text-input
                         (valueChange)="onInputChange({change: $event, data: data})"
                         [bgColor]="offWhite"
@@ -158,7 +158,7 @@
                     </app-text-input>
                   </div>
                   <div
-                        *ngIf="currentSelectedPiece.type === 'PIECE'"
+                        *ngIf="currentSelectedPiece.type === 'BALLET'"
                         class="adding-position-size-container">
                     <app-text-input
                         (valueChange)="onInputChange({change: $event, data: data})"

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -70,7 +70,7 @@ export class PieceEditor implements OnInit {
 
   currentTypeOffset = 0;
 
-  segmentTypes = ['SEGMENT', 'PIECE', 'SUPER'];
+  segmentTypes = ['SEGMENT', 'BALLET', 'SUPER'];
   selectedSegmentType: PieceType;
   segmentPrettyNames = ['', 'Segment', 'Ballet', 'Super Ballet'];
 
@@ -234,7 +234,7 @@ export class PieceEditor implements OnInit {
       return;
     }
     let name = 'TEST';
-    let type: PieceType = 'PIECE';
+    let type: PieceType = 'BALLET';
     let originalName = 'TEST';
     this.currentTypeOffset = pieceTpCd;
     switch (pieceTpCd) {
@@ -245,7 +245,7 @@ export class PieceEditor implements OnInit {
       break;
     case 2:
       name = 'New Ballet';
-      type = 'PIECE';
+      type = 'BALLET';
       originalName = 'New Ballet';
       break;
     case 3:
@@ -335,7 +335,7 @@ export class PieceEditor implements OnInit {
       this.workingPiece = this.currentSelectedPiece;
       this.setCurrentPiece(this.workingPiece);
     }
-    const createPosition = this.currentSelectedPiece.type === 'PIECE';
+    const createPosition = this.currentSelectedPiece.type === 'BALLET';
     this.creatingPiece = true;
     this.pieceSaved = false;
     const nextIndex = (this.currentSelectedPiece.positions.length +
@@ -462,7 +462,7 @@ export class PieceEditor implements OnInit {
     if (!this.currentSelectedPiece) {
       return;
     }
-    const createPosition = this.currentSelectedPiece.type === 'PIECE';
+    const createPosition = this.currentSelectedPiece.type === 'BALLET';
     if (this.pieceSaved) {
       // after deletePiece()
       this.dragAndDropData = this.currentSelectedPiece.positions
@@ -547,7 +547,7 @@ export class PieceEditor implements OnInit {
 
   getCurrentTypeCode(type: PieceType): number {
     let code = 0;
-    if (type === 'PIECE') {
+    if (type === 'BALLET') {
       code = 2;
     } else if (type === 'SUPER') {
       code = 3;

--- a/frontend/rolecall/src/app/services/cache_validator.service.ts
+++ b/frontend/rolecall/src/app/services/cache_validator.service.ts
@@ -5,7 +5,7 @@ export type CacheTag = CacheTags | string;
 
 export enum CacheTags {
   USER = "USER",
-  PIECES = "PIECES"
+  BALLETS = "BALLETS"
 }
 
 

--- a/frontend/rolecall/src/app/services/csv-generator.service.ts
+++ b/frontend/rolecall/src/app/services/csv-generator.service.ts
@@ -55,7 +55,7 @@ export class CsvGenerator {
     let headers = ['Performance', 'Piece', 'Length', 'Position',
       'Selected Cast', 'Cast Number', 'Dancer Number',
       'Dancer First', 'Dancer Last'];
-    let objs: any[][][][] = perf.step_3.segments.filter(s => this.pieceAPI.pieces.get(s.segment).type == "PIECE").map(seg => {
+    let objs: any[][][][] = perf.step_3.segments.filter(s => this.pieceAPI.pieces.get(s.segment).type == "BALLET").map(seg => {
       return seg.custom_groups.map(filledPos => {
         return filledPos.groups.map(g => {
           return g.members.sort((a, b) => a.position_number < b.position_number ? -1 : 1).map(m => {


### PR DESCRIPTION
I decided against changing 'section' to 'segment' on the backend. The main reason is that the database table is called Section and the framework code files should take their name from the table.

On the other hand, the old fronted name for the Ballets, Piece, had made its way into the backed as codes, constants, and function names. This PR changes the codes and constants from PIECE(S) to BALLET(S).

Because the codes transcend the api interfaces, it made sense to change the codes on the backend and frontend at the same time.

A second PR will deal with changing function names on the backend.