### PR TITLE
Piece to Ballet 2

### DIFF
--- a/frontend/rolecall/src/api_types.ts
+++ b/frontend/rolecall/src/api_types.ts
@@ -26,7 +26,7 @@ export namespace APITypes {
     canReceiveNotifications: boolean;
     managePerformances: boolean;
     manageCasts: boolean;
-    managePieces: boolean;
+    manageBallets: boolean;
     manageRoles: boolean;
     manageRules: boolean;
   };

--- a/frontend/rolecall/src/app/api/user_api.service.ts
+++ b/frontend/rolecall/src/app/api/user_api.service.ts
@@ -127,7 +127,7 @@ export class UserApi {
                 canReceiveNotifications: val.notifications,
                 managePerformances: val.managePerformances,
                 manageCasts: val.manageCasts,
-                managePieces: val.managePieces,
+                manageBallets: val.managePieces,
                 manageRoles: val.manageRoles,
                 manageRules: val.manageRules
               },
@@ -188,7 +188,7 @@ export class UserApi {
         canReceiveNotifications: user.has_permissions.canReceiveNotifications,
         managePerformances: user.has_permissions.managePerformances,
         manageCasts: user.has_permissions.manageCasts,
-        managePieces: user.has_permissions.managePieces,
+        managePieces: user.has_permissions.manageBallets,
         manageRoles: user.has_permissions.manageRoles,
         manageRules: user.has_permissions.manageRules,
         // Other
@@ -223,7 +223,7 @@ export class UserApi {
         canReceiveNotifications: user.has_permissions.canReceiveNotifications,
         managePerformances: user.has_permissions.managePerformances,
         manageCasts: user.has_permissions.manageCasts,
-        managePieces: user.has_permissions.managePieces,
+        managePieces: user.has_permissions.manageBallets,
         manageRoles: user.has_permissions.manageRoles,
         manageRules: user.has_permissions.manageRules,
         // Other

--- a/frontend/rolecall/src/app/mocks/mock_user_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_user_backend.ts
@@ -17,7 +17,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -50,7 +50,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -83,7 +83,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -116,7 +116,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -149,7 +149,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -182,7 +182,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -216,7 +216,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -249,7 +249,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -282,7 +282,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -315,7 +315,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -348,7 +348,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -381,7 +381,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -414,7 +414,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -447,7 +447,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -480,7 +480,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -513,7 +513,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -546,7 +546,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -579,7 +579,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -612,7 +612,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -645,7 +645,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -678,7 +678,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -711,7 +711,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -744,7 +744,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -777,7 +777,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -810,7 +810,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -843,7 +843,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -876,7 +876,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -909,7 +909,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -942,7 +942,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },
@@ -975,7 +975,7 @@ export class MockUserBackend {
         "canReceiveNotifications": true,
         "managePerformances": false,
         "manageCasts": false,
-        "managePieces": false,
+        "manageBallets": false,
         "manageRoles": false,
         "manageRules": false
       },

--- a/frontend/rolecall/src/app/user/user-editor.component.ts
+++ b/frontend/rolecall/src/app/user/user-editor.component.ts
@@ -80,7 +80,7 @@ export class UserEditor implements OnInit {
     canReceiveNotifications: 'Receives Notifications',
     managePerformances: 'Manages Performances',
     manageCasts: 'Manages Casts',
-    managePieces: 'Manages Pieces',
+    manageBallets: 'Manages Ballets',
     manageRoles: 'Manages Roles',
     manageRules: 'Manages Rules',
   };
@@ -228,7 +228,7 @@ export class UserEditor implements OnInit {
         canReceiveNotifications: true,
         managePerformances: false,
         manageCasts: false,
-        managePieces: false,
+        manageBallets: false,
         manageRoles: false,
         manageRules: false
       },


### PR DESCRIPTION
After looking at the backend, I decided against making any changes because the only time Piece appears is when referring to the 'managePieces' field in the User table which is as it should be. (We can only change the Pieces name if we also change the field / column name in the User table.)

So the only 'necessary' change left is to change the user interface. These changes change the text displayed in the Users screen from 'Manage Pieces' to 'Manage Ballets' as well as the associated field in the User object. (I didn't change the associated field in the RawUser object as that is supposed to match the backend.)

Most of the diffs come from the field name change in the mock database.

I am not committed to changing more names from Piece to Ballet (such as source files and directories) unless the team feels it is the right thing to do.