### PR TITLE
Remove namespace usage with minimal impact on existing code

### DIFF
--- a/frontend/rolecall/src/api_types.ts
+++ b/frontend/rolecall/src/api_types.ts
@@ -4,34 +4,31 @@ export enum PerformanceStatus {
   CANCELED = 'CANCELED'
 }
 
-/** All the types needed for APIs. */
-export namespace APITypes {
-  export type UserUUID = string;
-  export type PieceUUID = string;
-  export type CastUUID = string;
-  export type PerformanceUUID = string;
-  export type UnavailabilityUUID = number;
-  export type SuccessIndicator = {
-    successful: boolean;
-    error?: string;
-  };
-  export type Roles = {
-    isAdmin: boolean;
-    isCoreographer: boolean;
-    isDancer: boolean;
-    isOther: boolean;
-  };
-  export type Permissions = {
-    canLogin: boolean;
-    canReceiveNotifications: boolean;
-    managePerformances: boolean;
-    manageCasts: boolean;
-    manageBallets: boolean;
-    manageRoles: boolean;
-    manageRules: boolean;
-  };
-  export type Position = {
-    segment: PieceUUID;
-    position: string;
-  };
-}
+export type UserUUID = string;
+export type PieceUUID = string;
+export type CastUUID = string;
+export type PerformanceUUID = string;
+export type UnavailabilityUUID = number;
+export type SuccessIndicator = {
+  successful: boolean;
+  error?: string;
+};
+export type Roles = {
+  isAdmin: boolean;
+  isCoreographer: boolean;
+  isDancer: boolean;
+  isOther: boolean;
+};
+export type Permissions = {
+  canLogin: boolean;
+  canReceiveNotifications: boolean;
+  managePerformances: boolean;
+  manageCasts: boolean;
+  manageBallets: boolean;
+  manageRoles: boolean;
+  manageRules: boolean;
+};
+export type Position = {
+  segment: PieceUUID;
+  position: string;
+};

--- a/frontend/rolecall/src/app/api/cast_api.service.ts
+++ b/frontend/rolecall/src/app/api/cast_api.service.ts
@@ -1,6 +1,6 @@
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {environment} from 'src/environments/environment';
 
 import {MockCastBackend} from '../mocks/mock_cast_backend';

--- a/frontend/rolecall/src/app/api/performance-api.service.ts
+++ b/frontend/rolecall/src/app/api/performance-api.service.ts
@@ -1,7 +1,8 @@
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
-import {APITypes, PerformanceStatus} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {environment} from 'src/environments/environment';
+
 import {MockPerformanceBackend} from '../mocks/mock_performance_backend';
 import {HeaderUtilityService} from '../services/header-utility.service';
 import {LoggingService} from '../services/logging.service';
@@ -9,9 +10,9 @@ import {ResponseStatusHandlerService} from '../services/response-status-handler.
 
 export type Performance = {
   uuid: string,
-  status: PerformanceStatus.DRAFT |
-      PerformanceStatus.PUBLISHED |
-      PerformanceStatus.CANCELED,
+  status: APITypes.PerformanceStatus.DRAFT |
+      APITypes.PerformanceStatus.PUBLISHED |
+      APITypes.PerformanceStatus.CANCELED,
   step_1: {
     title: string,
     date: number,
@@ -125,7 +126,8 @@ export class PerformanceApi {
       status: (raw.status === 'DRAFT' || raw.status === 'PUBLISHED'
                || raw.status
                === 'CANCELED')
-          ? PerformanceStatus[raw.status] : PerformanceStatus.DRAFT,
+          ? APITypes.PerformanceStatus[raw.status] :
+          APITypes.PerformanceStatus.DRAFT,
       step_1: {
         title: raw.title,
         description: raw.description,
@@ -186,7 +188,7 @@ export class PerformanceApi {
       venue: perf.step_1.venue,
       state: perf.step_1.state,
       dateTime: perf.step_1.date,
-      status: perf.status ? perf.status : PerformanceStatus.DRAFT,
+      status: perf.status ? perf.status : APITypes.PerformanceStatus.DRAFT,
       performanceSections: perf.step_3.segments.map((seg, segIx) => {
         return {
           id: seg.id ? Number(seg.id) : undefined,

--- a/frontend/rolecall/src/app/api/piece_api.service.ts
+++ b/frontend/rolecall/src/app/api/piece_api.service.ts
@@ -1,7 +1,8 @@
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {environment} from 'src/environments/environment';
+
 import {MockPieceBackend} from '../mocks/mock_piece_backend';
 import {HeaderUtilityService} from '../services/header-utility.service';
 import {LoggingService} from '../services/logging.service';

--- a/frontend/rolecall/src/app/api/unavailability-api.service.ts
+++ b/frontend/rolecall/src/app/api/unavailability-api.service.ts
@@ -1,7 +1,8 @@
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {environment} from 'src/environments/environment';
+
 import {MockUnavailabilityBackend} from '../mocks/mock_unavailability_backend';
 import {HeaderUtilityService} from '../services/header-utility.service';
 import {LoggingService} from '../services/logging.service';

--- a/frontend/rolecall/src/app/api/user_api.service.ts
+++ b/frontend/rolecall/src/app/api/user_api.service.ts
@@ -1,9 +1,10 @@
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
 import * as moment from 'moment';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {environment} from 'src/environments/environment';
 import {isNullOrUndefined} from 'util';
+
 import {MockUserBackend} from '../mocks/mock_user_backend';
 import {HeaderUtilityService} from '../services/header-utility.service';
 import {LoggingService} from '../services/logging.service';

--- a/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-drag-and-drop.component.ts
@@ -1,6 +1,6 @@
 import {CdkDragDrop} from '@angular/cdk/drag-drop';
 import {Component, EventEmitter, OnInit, Output} from '@angular/core';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {CAST_COUNT} from 'src/constants';
 
 import {Cast, CastApi, CastGroup} from '../api/cast_api.service';

--- a/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
+++ b/frontend/rolecall/src/app/cast/cast-editor-v2.component.ts
@@ -1,8 +1,9 @@
 import {Location} from '@angular/common';
 import {Component, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {CAST_COUNT} from 'src/constants';
+
 import {Cast, CastApi} from '../api/cast_api.service';
 import {Piece, PieceApi} from '../api/piece_api.service';
 import {CastDragAndDrop} from './cast-drag-and-drop.component';

--- a/frontend/rolecall/src/app/mocks/mock_cast_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_cast_backend.ts
@@ -1,5 +1,6 @@
 import {HttpResponse} from '@angular/common/http';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
+
 import {AllCastsResponse, Cast, OneCastResponse} from '../api/cast_api.service';
 
 /**

--- a/frontend/rolecall/src/app/mocks/mock_performance_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_performance_backend.ts
@@ -1,5 +1,6 @@
 import {HttpResponse} from '@angular/common/http';
-import {APITypes, PerformanceStatus} from 'src/api_types';
+import * as APITypes from 'src/api_types';
+
 import {AllPerformancesResponse, OnePerformanceResponse, Performance} from '../api/performance-api.service';
 
 /** Mocks the piece backend responses. */
@@ -9,7 +10,7 @@ export class MockPerformanceBackend {
   mockPerformanceDB: Performance[] = [
     {
       uuid: 'performance1:' + Date.now(),
-      status: PerformanceStatus.PUBLISHED,
+      status: APITypes.PerformanceStatus.PUBLISHED,
       step_1: {
         title: 'Test Title 1',
         date: (Date.now() - 600000),
@@ -76,7 +77,7 @@ export class MockPerformanceBackend {
     },
     {
       uuid: 'performance2:' + Date.now(),
-      status: PerformanceStatus.DRAFT,
+      status: APITypes.PerformanceStatus.DRAFT,
       step_1: {
         title: 'Test Title 2',
         date: (Date.now() - 600000),

--- a/frontend/rolecall/src/app/mocks/mock_piece_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_piece_backend.ts
@@ -1,5 +1,6 @@
 import {HttpResponse} from '@angular/common/http';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
+
 import {AllPiecesResponse, OnePieceResponse, Piece} from '../api/piece_api.service';
 
 /**

--- a/frontend/rolecall/src/app/mocks/mock_unavailability_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_unavailability_backend.ts
@@ -1,5 +1,6 @@
 import {HttpResponse} from '@angular/common/http';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
+
 import {AllUnavailabilitiesResponse, OneUnavailabilityResponse, Unavailability} from '../api/unavailability-api.service';
 
 /** Mocks the unavailability backend responses. */

--- a/frontend/rolecall/src/app/mocks/mock_user_backend.ts
+++ b/frontend/rolecall/src/app/mocks/mock_user_backend.ts
@@ -1,6 +1,7 @@
 import {HttpResponse} from '@angular/common/http';
-import {APITypes} from 'src/api_types';
+import * as APITypes from 'src/api_types';
 import {isNullOrUndefined} from 'util';
+
 import {AllUsersResponse, OneUserResponse, User} from '../api/user_api.service';
 
 /**

--- a/frontend/rolecall/src/app/piece/piece_editor.component.ts
+++ b/frontend/rolecall/src/app/piece/piece_editor.component.ts
@@ -4,9 +4,10 @@ import {Component, OnInit} from '@angular/core';
 import {MatSelectChange} from '@angular/material/select';
 import {ActivatedRoute} from '@angular/router';
 import {COLORS} from 'src/constants';
+import * as APITypes from 'src/api_types';
+
 import {Piece, PieceApi, PieceType, Position} from '../api/piece_api.service';
 import {ResponseStatusHandlerService} from '../services/response-status-handler.service';
-import {APITypes} from 'src/api_types';
 
 type ValueName =
     'New Position' |


### PR DESCRIPTION
Would love to get rid of the APITypes prefix completely, but it can be considered as a separate PR in the future.