### PR TITLE
Change delete logic for Super Ballets

### DIFF
--- a/backend/src/main/java/com/google/rolecall/services/SectionServices.java
+++ b/backend/src/main/java/com/google/rolecall/services/SectionServices.java
@@ -223,6 +223,13 @@ public class SectionServices {
                     "Cannot delete Position if it has a cast or is involved in a performance.");
           }
 
+          if(positionToDelete.getSiblingId() > 0) {
+            try {
+              sectionRepo.deleteById(positionToDelete.getSiblingId());
+            } catch(IllegalArgumentException e) {
+            }
+          }
+
           section.removePosition(positionToDelete);
           siblingIndexArray[loopCounter] = -1;
           continue;
@@ -275,31 +282,31 @@ public class SectionServices {
    * Deletes an existing {@link Section} object by id and all children objects.
    * 
    * @param id Unique id for the {@link Section} object to be deleted
-   * @throws EntityNotFoundException The id does not match and existing {@link Section}
+   * @throws EntityNotFoundException if thee id does not match an existing {@link Section}
    *    in the database.
    */
   public void deleteSection(int id) throws EntityNotFoundException, InvalidParameterException {
-    checkDeleteOk(id, false);
+    assertDeleteIsAllowed(id, false);
     Section section = getSection(id);
 
     if(section.getType() == Section.Type.SUPER) {
       // Check that all children are OK to delete
       for(Position position: section.getPositions()) {
         Integer childId = position.getSiblingId();
-        if(childId != 0 && childId > 0) {
+        if(childId > 0) {
           Optional<Section> childQuery = sectionRepo.findById(childId);
           if(!childQuery.isEmpty()) {
-            checkDeleteOk(childId, true);
+            assertDeleteIsAllowed(childId, true);
           }
         }
       }
-      // If none of the children have a deleate problem, we can delete
+      // If none of the children have a delete problem, we can delete
       for(Position position: section.getPositions()) {
         Integer childId = position.getSiblingId();
-        if(childId != 0 && childId > 0) {
-          Optional<Section> childQuery = sectionRepo.findById(childId);
-          if(!childQuery.isEmpty()) { 
+        if(childId > 0) {
+          try {
             sectionRepo.deleteById(childId);
+          } catch(IllegalArgumentException e) {
           }
         }
       }
@@ -308,11 +315,29 @@ public class SectionServices {
   }
 
   // Utility functions
-  private void checkDeleteOk(int id, boolean superChildIsOk) throws EntityNotFoundException, InvalidParameterException {
+
+    /** 
+   * Ensures that the Super Ballet and all its chilren are allowed to be deleted.
+   * This means,
+   * 1) they must not have casts associated with them,
+   * 2) they must not be included in any performance, or
+   * 3) a Super Ballet child must not be deleted "from the outside" --
+   * it must be deleted from inside the Super Ballet.
+   * 
+   * @param id For the Super Ballet, this is the standard section id. For the
+   *    children, this is the siblingId in every position / ballet child.
+   * @param deleteSuperChildIsOk marks that condition 3) is not the case. We are on the
+   *    inside, and it is OK to delete a Super Ballet Child.
+   * @throws EntityNotFoundException if the id does not match an existing {@link Section}
+   *    in the database.
+   * @throws InvalidParameterException if conditions 1) through 3) are false.
+   */
+  private void assertDeleteIsAllowed(int id, boolean deleteSuperChildIsOk)
+      throws EntityNotFoundException, InvalidParameterException {
     Section section = getSection(id);
 
     Integer siblingId = section.getSiblingId();
-    if(!superChildIsOk && siblingId != null) {
+    if(!deleteSuperChildIsOk && siblingId != null) {
       Optional<Position> test = positionRepo.findById(siblingId);
       if(test.isEmpty()) {
         // Super Ballet's internal Ballet/Position structure has already been deleted
@@ -369,7 +394,7 @@ public class SectionServices {
               .setNotes(sibling.getNotes())
               .setOrder(sibling.getOrder())
               .setSiblingId(siblingId == -1 ? sibling.getSiblingId() : siblingId)
-              .setSize(null)
+              .setSize(-1)
               .build();
           positionRepo.save(updatedSibling);
         } catch (InvalidParameterException e) {


### PR DESCRIPTION
One request we received from the customer on Thursday was that we change the delete logic for Super Ballets. Originally, we weren't sure how closely the customer wanted to couple Super Ballets and their children. If a Super Ballet is killed, should it be possible for its children to survive as independent entities? Originally, we thought the answer was yes.

The customer told us on Thursday that the answer is no. If you kill a Super Ballet, they expected all children to be killed as well.

This PR fixes the delete issue. I also fixed an assignment mistake where the "position size" (an important value for a position but a nonsense value for a super ballet child) was set equal to the siblingId -- probably cased by a sloppy copy paste. I changed it to null, which makes more sense.

I apologize for giving you backend code to review, but I really like your reviews. Besides, you reviewed this code before, so you probably half know it already.