### PR TITLE
Reducing maximum number of concurrent threads

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -11,8 +11,8 @@ server.servlet.session.cookie.secure=false
 server.servlet.session.cookie.name=SESSIONID
 
 # Multi-Threading Configuration
-thread.pool.size=20
-max.queue.capacity=20
+thread.pool.size=3
+max.queue.capacity=1000
 allow.core.thread.timeout=true
 wait.for.task.completion.on.shutdown=true
 await.termination=60

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -9,8 +9,8 @@ server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.name=SESSIONID
 
 # Multi-Threading Configuration
-thread.pool.size=20
-max.queue.capacity=20
+thread.pool.size=3
+max.queue.capacity=1000
 allow.core.thread.timeout=true
 wait.for.task.completion.on.shutdown=true
 await.termination=60

--- a/backend/src/main/resources/application-qa.properties
+++ b/backend/src/main/resources/application-qa.properties
@@ -9,8 +9,8 @@ server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.name=SESSIONID
 
 # Multi-Threading Configuration
-thread.pool.size=20
-max.queue.capacity=20
+thread.pool.size=3
+max.queue.capacity=1000
 allow.core.thread.timeout=true
 wait.for.task.completion.on.shutdown=true
 await.termination=60


### PR DESCRIPTION
Currently, the number of requests a client makes is linked to the some factor in the size of the performance causing nearly 30 calls before crashing to be made simultaneously. Since each thread can be between ~40MB and ~80MB, memory would run out. Reducing total possible threads and increasing queue capacity should help with this, but an FE refactoring may be needing to find the root issue and improve performance.